### PR TITLE
SQLLEN for buffer length

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ fn it_works() {
                     for j in 1..columns {
                         let mut indicator : SQLLEN = 0;
                         let mut buf = [0; 512];
-                        ret = SQLGetData(stmt, j as u16, 1, buf.as_mut_ptr() as SQLPOINTER, buf.len() as i64, &mut indicator);
+                        ret = SQLGetData(stmt, j as u16, 1, buf.as_mut_ptr() as SQLPOINTER, buf.len() as SQLLEN, &mut indicator);
                         if ret & !1 == 0 {
                             if indicator == -1 {
                                 println!("Column {}: NULL", j);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ fn it_works() {
                     for j in 1..columns {
                         let mut indicator : SQLLEN = 0;
                         let mut buf = [0; 512];
-                        ret = SQLGetData(stmt, j as u16, 1, buf.as_mut_ptr() as SQLPOINTER, buf.len() as i64, &mut indicator);
+                        ret = SQLGetData(stmt, j as u16, 1, buf.as_mut_ptr() as SQLPOINTER, buf.len() as SQLLEN, &mut indicator);
                         if ret & !1 == 0 {
                             if indicator == -1 {
                                 println!("Column {}: NULL", j);


### PR DESCRIPTION
On my system (stable-x64-msvc) c_long is an i32. The test code does therefore not compile on my machine. Using SQLLEN should work fine on all platforms.