### PR TITLE
List odbc datasources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ before_install:
   - sudo apt-get install -y unixodbc unixodbc-dev odbc-postgresql libsqliteodbc
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres
+  - export ODBCINI=${PWD}/travis/odbc.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,5 @@ services:
   - postgresql
 before_install:
   - sudo apt-get install -y unixodbc unixodbc-dev odbc-postgresql libsqliteodbc
+before_script:
+  - psql -c 'create database travis_ci_test;' -U postgres

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -14,7 +14,7 @@ pub struct Environment {
 /// Holds name and description of a datasource
 ///
 /// Can be obtained via `Environment::data_sources`
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DataSourceInfo {
     /// Name of the data source
     pub server_name: String,
@@ -25,7 +25,7 @@ pub struct DataSourceInfo {
 /// Struct holding information available on a driver.
 ///
 /// Can be obtained via `Environment::drivers`
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DriverInfo {
     /// Name of the odbc driver
     pub description: String,

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,7 +1,6 @@
 //! This module implements the ODBC Environment
 use super::{Error, DiagRec, Result, raw};
 use std::collections::HashMap;
-use std::ffi::CStr;
 use std;
 
 /// Handle to an ODBC Environment
@@ -74,47 +73,27 @@ impl Environment {
     pub fn drivers(&self) -> Result<Vec<DriverInfo>> {
         // Iterate twice, once for reading the maximum required buffer lengths so we can read
         // everything without truncating and a second time for actually storing the values
-        let mut desc_length_out: raw::SQLSMALLINT = 0;
-        let mut attr_length_out: raw::SQLSMALLINT = 0;
-        let mut result;
-
         // alloc_info iterates ones over every driver to obtain the requiered buffer sizes
-        let (max_desc, max_attr, num_drivers) = self.alloc_info(raw::SQLDrivers)?;
+        let (max_desc, max_attr, num_drivers) =
+            unsafe { self.alloc_info(raw::SQLDrivers, raw::SQL_FETCH_FIRST) }?;
 
         let mut driver_list = Vec::with_capacity(num_drivers);
+        let mut description_buffer: Vec<_> = (0..(max_desc + 1)).map(|_| 0u8).collect();
+        let mut attribute_buffer: Vec<_> = (0..(max_attr + 1)).map(|_| 0u8).collect();
+
         loop {
-            let mut description_buffer: Vec<_> = (0..(max_desc + 1)).map(|_| 0u8).collect();
-            let mut attribute_buffer: Vec<_> = (0..(max_attr + 1)).map(|_| 0u8).collect();
-            unsafe {
-                result = raw::SQLDrivers(self.handle,
-                                         // Its ok to use fetch next here, since we know
-                                         // last state has been SQL_NO_DATA
-                                         raw::SQL_FETCH_NEXT,
-                                         &mut description_buffer[0] as *mut u8,
-                                         max_desc + 1,
-                                         &mut desc_length_out as *mut raw::SQLSMALLINT,
-                                         &mut attribute_buffer[0] as *mut u8,
-                                         max_attr + 1,
-                                         &mut attr_length_out as *mut raw::SQLSMALLINT);
-            }
-            match result {
-                raw::SQL_SUCCESS |
-                raw::SQL_SUCCESS_WITH_INFO => {
-                    description_buffer.resize(desc_length_out as usize, 0);
-                    driver_list.push(DriverInfo {
-                        description: String::from_utf8(description_buffer)
-                            .expect("String returned by Driver Manager should be utf8 encoded"),
-                        attributes: Self::parse_attributes(attribute_buffer),
-                    })
-                }
-                raw::SQL_ERROR => unsafe {
-                    return Err(Error::SqlError(DiagRec::create(raw::SQL_HANDLE_ENV, self.handle)));
-                },
-                raw::SQL_NO_DATA => break,
-                /// The only other value allowed by ODBC here is SQL_INVALID_HANDLE. We protect the
-                /// validity of this handle with our invariant. In save code the user should not be
-                /// able to reach this code path.
-                _ => panic!("Environment invariant violated"),
+            if let Some((desc, attr)) = unsafe {
+                self.get_info(raw::SQLDrivers,
+                              raw::SQL_FETCH_NEXT,
+                              &mut description_buffer,
+                              &mut attribute_buffer)
+            }? {
+                driver_list.push(DriverInfo {
+                    description: desc.to_owned(),
+                    attributes: Self::parse_attributes(attr),
+                })
+            } else {
+                break;
             }
         }
         Ok(driver_list)
@@ -122,58 +101,58 @@ impl Environment {
 
     /// Stores all data source server names and descriptions in a Vec
     pub fn data_sources(&self) -> Result<Vec<DataSourceInfo>> {
-        // Iterate twice, once for reading the maximum required buffer lengths so we can read
-        // everything without truncating and a second time for actually storing the values
-        let mut name_length_out: raw::SQLSMALLINT = 0;
-        let mut desc_length_out: raw::SQLSMALLINT = 0;
-        let mut result;
+        unsafe { self.data_sources_impl(raw::SQL_FETCH_FIRST) }
+    }
+
+    /// Stores all sytem data source server names and descriptions in a Vec
+    pub fn system_data_sources(&self) -> Result<Vec<DataSourceInfo>> {
+        unsafe { self.data_sources_impl(raw::SQL_FETCH_FIRST_SYSTEM) }
+    }
+
+    /// Stores all user data source server names and descriptions in a Vec
+    pub fn user_data_sources(&self) -> Result<Vec<DataSourceInfo>> {
+        unsafe { self.data_sources_impl(raw::SQL_FETCH_FIRST_USER) }
+    }
+
+    /// Use SQL_FETCH_FIRST, SQL_FETCH_FIRST_USER or SQL_FETCH_FIRST_SYSTEM, to get all, user or
+    /// system data sources
+    unsafe fn data_sources_impl(&self,
+                                direction: raw::SQLUSMALLINT)
+                                -> Result<Vec<DataSourceInfo>> {
 
         // alloc_info iterates ones over every datasource to obtain the requiered buffer sizes
-        let (max_name, max_desc, num_sources) = self.alloc_info(raw::SQLDataSources)?;
+        let (max_name, max_desc, num_sources) = self.alloc_info(raw::SQLDataSources, direction)?;
 
         let mut source_list = Vec::with_capacity(num_sources);
         let mut name_buffer: Vec<_> = (0..(max_name + 1)).map(|_| 0u8).collect();
         let mut description_buffer: Vec<_> = (0..(max_desc + 1)).map(|_| 0u8).collect();
 
+        // Before we call SQLDataSources with SQL_FETCH_NEXT, we have to call it with either
+        // SQL_FETCH_FIRST, SQL_FETCH_FIRST_USER or SQL_FETCH_FIRST_SYSTEM, to get all, user or
+        // system data sources
+        if let Some((name, desc)) = self.get_info(raw::SQLDataSources,
+                      direction,
+                      &mut name_buffer,
+                      &mut description_buffer)? {
+            source_list.push(DataSourceInfo {
+                server_name: name.to_owned(),
+                description: desc.to_owned(),
+            })
+        } else {
+            return Ok(source_list);
+        }
+
         loop {
-            unsafe {
-                result = raw::SQLDataSources(self.handle,
-                                             // Its ok to use fetch next here, since we know
-                                             // last state has been SQL_NO_DATA
-                                             raw::SQL_FETCH_NEXT,
-                                             &mut name_buffer[0] as *mut u8,
-                                             max_name + 1,
-                                             &mut name_length_out as *mut raw::SQLSMALLINT,
-                                             &mut description_buffer[0] as *mut u8,
-                                             max_desc + 1,
-                                             &mut desc_length_out as *mut raw::SQLSMALLINT);
-            }
-            match result {
-                raw::SQL_SUCCESS |
-                raw::SQL_SUCCESS_WITH_INFO => {
-                    let name = CStr::from_bytes_with_nul(name_buffer.as_slice())
-                        .unwrap()
-                        .to_str()
-                        .unwrap()
-                        .to_owned();
-                    let description = CStr::from_bytes_with_nul(description_buffer.as_slice())
-                        .unwrap()
-                        .to_str()
-                        .unwrap()
-                        .to_owned();
-                    source_list.push(DataSourceInfo {
-                        server_name: name,
-                        description: description,
-                    })
-                }
-                raw::SQL_ERROR => unsafe {
-                    return Err(Error::SqlError(DiagRec::create(raw::SQL_HANDLE_ENV, self.handle)));
-                },
-                raw::SQL_NO_DATA => break,
-                /// The only other value allowed by ODBC here is SQL_INVALID_HANDLE. We protect the
-                /// validity of this handle with our invariant. In save code the user should not be
-                /// able to reach this code path.
-                _ => panic!("Environment invariant violated"),
+            if let Some((name, desc)) = self.get_info(raw::SQLDataSources,
+                          raw::SQL_FETCH_NEXT,
+                          &mut name_buffer,
+                          &mut description_buffer)? {
+                source_list.push(DataSourceInfo {
+                    server_name: name.to_owned(),
+                    description: desc.to_owned(),
+                })
+            } else {
+                break;
             }
         }
         Ok(source_list)
@@ -197,27 +176,61 @@ impl Environment {
         }
     }
 
-    fn alloc_info(&self,
-                  f: SqlInfoFunction)
-                  -> Result<(raw::SQLSMALLINT, raw::SQLSMALLINT, usize)> {
+    unsafe fn get_info<'a, 'b>(&self,
+                               f: SqlInfoFunction,
+                               direction: raw::SQLUSMALLINT,
+                               buf1: &'a mut [u8],
+                               buf2: &'b mut [u8])
+                               -> Result<Option<(&'a str, &'b str)>> {
+        let mut len1: raw::SQLSMALLINT = 0;
+        let mut len2: raw::SQLSMALLINT = 0;
+
+        let result = f(self.handle,
+                       // Its ok to use fetch next here, since we know
+                       // last state has been SQL_NO_DATA
+                       direction,
+                       &mut buf1[0] as *mut u8,
+                       buf1.len() as raw::SQLSMALLINT,
+                       &mut len1 as *mut raw::SQLSMALLINT,
+                       &mut buf2[0] as *mut u8,
+                       buf2.len() as raw::SQLSMALLINT,
+                       &mut len2 as *mut raw::SQLSMALLINT);
+        match result {
+            raw::SQL_SUCCESS |
+            raw::SQL_SUCCESS_WITH_INFO => {
+                Ok(Some((std::str::from_utf8(&buf1[0..(len1 as usize)]).unwrap(),
+                         std::str::from_utf8(&buf2[0..(len2 as usize)]).unwrap())))
+            }
+            raw::SQL_ERROR => {
+                Err(Error::SqlError(DiagRec::create(raw::SQL_HANDLE_ENV, self.handle)))
+            }
+            raw::SQL_NO_DATA => Ok(None),
+            /// The only other value allowed by ODBC here is SQL_INVALID_HANDLE. We protect the
+            /// validity of this handle with our invariant. In save code the user should not be
+            /// able to reach this code path.
+            _ => panic!("Environment invariant violated"),
+        }
+    }
+
+    /// Finds the maximum size required for description buffers
+    unsafe fn alloc_info(&self,
+                         f: SqlInfoFunction,
+                         direction: raw::SQLUSMALLINT)
+                         -> Result<(raw::SQLSMALLINT, raw::SQLSMALLINT, usize)> {
         let string_buf = std::ptr::null_mut();
         let mut buf1_length_out: raw::SQLSMALLINT = 0;
         let mut buf2_length_out: raw::SQLSMALLINT = 0;
         let mut max1 = 0;
         let mut max2 = 0;
         let mut count = 0;
-        let mut result = unsafe {
-            // Although the rather lengthy function call kind of blows the code, let's do the first
-            // one using SQL_FETCH_FIRST, so we list all drivers independent from environment state
-            f(self.handle,
-              raw::SQL_FETCH_FIRST,
-              string_buf,
-              0,
-              &mut buf1_length_out as *mut raw::SQLSMALLINT,
-              string_buf,
-              0,
-              &mut buf2_length_out as *mut raw::SQLSMALLINT)
-        };
+        let mut result = f(self.handle,
+                           direction,
+                           string_buf,
+                           0,
+                           &mut buf1_length_out as *mut raw::SQLSMALLINT,
+                           string_buf,
+                           0,
+                           &mut buf2_length_out as *mut raw::SQLSMALLINT);
         loop {
             match result {
                 raw::SQL_SUCCESS |
@@ -227,24 +240,23 @@ impl Environment {
                     max2 = std::cmp::max(max2, buf2_length_out);
                 }
                 raw::SQL_NO_DATA => break,
-                raw::SQL_ERROR => unsafe {
+                raw::SQL_ERROR => {
                     return Err(Error::SqlError(DiagRec::create(raw::SQL_HANDLE_ENV, self.handle)));
-                },
+                }
                 /// The only other value allowed by ODBC here is SQL_INVALID_HANDLE. We protect the
                 /// validity of this handle with our invariant. In save code the user should not be
                 /// able to reach this code path.
                 _ => panic!("Environment invariant violated"),
             }
-            unsafe {
-                result = f(self.handle,
-                           raw::SQL_FETCH_NEXT,
-                           string_buf,
-                           0,
-                           &mut buf1_length_out as *mut raw::SQLSMALLINT,
-                           string_buf,
-                           0,
-                           &mut buf2_length_out as *mut raw::SQLSMALLINT);
-            }
+
+            result = f(self.handle,
+                       raw::SQL_FETCH_NEXT,
+                       string_buf,
+                       0,
+                       &mut buf1_length_out as *mut raw::SQLSMALLINT,
+                       string_buf,
+                       0,
+                       &mut buf2_length_out as *mut raw::SQLSMALLINT);
         }
 
         Ok((max1, max2, count))
@@ -253,10 +265,8 @@ impl Environment {
     /// Called by drivers to pares list of attributes
     ///
     /// Key value pairs are seperated by `\0`. Key and value are seperated by `=`
-    fn parse_attributes(attribute_buffer: Vec<u8>) -> HashMap<String, String> {
-        String::from_utf8(attribute_buffer)
-            .expect("String returned by Driver Manager should be utf8 encoded")
-            .split('\0')
+    fn parse_attributes(attributes: &str) -> HashMap<String, String> {
+        attributes.split('\0')
             .take_while(|kv_str| *kv_str != String::new())
             .map(|kv_str| {
                 let mut iter = kv_str.split('=');
@@ -284,11 +294,7 @@ mod test {
     #[test]
     fn parse_attributes() {
         let buffer = "APILevel=2\0ConnectFunctions=YYY\0CPTimeout=60\0DriverODBCVer=03.\
-                      50\0FileUsage=0\0SQLLevel=1\0UsageCount=1\0\0"
-            .as_bytes()
-            .iter()
-            .cloned()
-            .collect();
+                      50\0FileUsage=0\0SQLLevel=1\0UsageCount=1\0\0";
         let attributes = Environment::parse_attributes(buffer);
         assert_eq!(attributes["APILevel"], "2");
         assert_eq!(attributes["ConnectFunctions"], "YYY");

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -80,21 +80,16 @@ impl Environment {
         let mut driver_list = Vec::with_capacity(num_drivers);
         let mut description_buffer: Vec<_> = (0..(max_desc + 1)).map(|_| 0u8).collect();
         let mut attribute_buffer: Vec<_> = (0..(max_attr + 1)).map(|_| 0u8).collect();
-
-        loop {
-            if let Some((desc, attr)) = unsafe {
-                self.get_info(raw::SQLDrivers,
-                              raw::SQL_FETCH_NEXT,
-                              &mut description_buffer,
-                              &mut attribute_buffer)
-            }? {
-                driver_list.push(DriverInfo {
-                    description: desc.to_owned(),
-                    attributes: Self::parse_attributes(attr),
-                })
-            } else {
-                break;
-            }
+        while let Some((desc, attr)) = unsafe {
+            self.get_info(raw::SQLDrivers,
+                          raw::SQL_FETCH_NEXT,
+                          &mut description_buffer,
+                          &mut attribute_buffer)
+        }? {
+            driver_list.push(DriverInfo {
+                description: desc.to_owned(),
+                attributes: Self::parse_attributes(attr),
+            })
         }
         Ok(driver_list)
     }
@@ -142,18 +137,14 @@ impl Environment {
             return Ok(source_list);
         }
 
-        loop {
-            if let Some((name, desc)) = self.get_info(raw::SQLDataSources,
-                          raw::SQL_FETCH_NEXT,
-                          &mut name_buffer,
-                          &mut description_buffer)? {
-                source_list.push(DataSourceInfo {
-                    server_name: name.to_owned(),
-                    description: desc.to_owned(),
-                })
-            } else {
-                break;
-            }
+        while let Some((name, desc)) = self.get_info(raw::SQLDataSources,
+                      raw::SQL_FETCH_NEXT,
+                      &mut name_buffer,
+                      &mut description_buffer)? {
+            source_list.push(DataSourceInfo {
+                server_name: name.to_owned(),
+                description: desc.to_owned(),
+            })
         }
         Ok(source_list)
     }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -176,6 +176,8 @@ impl Environment {
         }
     }
 
+    /// Calls either SQLDrivers or SQLDataSources with the two given buffers and parses the result
+    /// into a `(&str,&str)`
     unsafe fn get_info<'a, 'b>(&self,
                                f: SqlInfoFunction,
                                direction: raw::SQLUSMALLINT,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,11 @@ mod test {
             .expect("Data sources can be iterated over");
         println!("{:?}", sources);
 
-        let expected: [String; 0] = [];
-        assert!(sources.iter().map(|d| &d.server_name).eq(expected.iter()));
+        let expected = [DataSourceInfo {
+                            server_name: "PostgreSQL".to_owned(),
+                            description: "PostgerSQL Unicode".to_owned(),
+                        }];
+        assert!(sources.iter().eq(expected.iter()));
     }
 
     #[test]
@@ -44,8 +47,11 @@ mod test {
             .expect("Data sources can be iterated over");
         println!("{:?}", sources);
 
-        let expected: [String; 0] = [];
-        assert!(sources.iter().map(|d| &d.server_name).eq(expected.iter()));
+        let expected = [DataSourceInfo {
+                            server_name: "PostgreSQL".to_owned(),
+                            description: "PostgerSQL Unicode".to_owned(),
+                        }];
+        assert!(sources.iter().eq(expected.iter()));
     }
 
     #[test]
@@ -56,8 +62,8 @@ mod test {
             .expect("Data sources can be iterated over");
         println!("{:?}", sources);
 
-        let expected: [String; 0] = [];
-        assert!(sources.iter().map(|d| &d.server_name).eq(expected.iter()));
+        let expected: [DataSourceInfo; 0] = [];
+        assert!(sources.iter().eq(expected.iter()));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,19 @@ mod test {
     }
 
     #[test]
+    fn list_data_sources() {
+        let environment = Environment::new();
+        let sources = environment.expect("Environment can be created")
+            .data_sources()
+            .expect("Data sources can be iterated over");
+        println!("{:?}", sources);
+
+        let expected: [String; 0] = [];
+        assert!(sources.iter().map(|d| &d.server_name).eq(expected.iter()));
+        assert!(false);
+    }
+
+    #[test]
     fn provoke_error() {
         use std;
         let mut environment = Environment::new().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,22 +34,7 @@ mod test {
 
         let expected = [DataSourceInfo {
                             server_name: "PostgreSQL".to_owned(),
-                            description: "PostgerSQL Unicode".to_owned(),
-                        }];
-        assert!(sources.iter().eq(expected.iter()));
-    }
-
-    #[test]
-    fn list_system_data_sources() {
-        let environment = Environment::new();
-        let sources = environment.expect("Environment can be created")
-            .system_data_sources()
-            .expect("Data sources can be iterated over");
-        println!("{:?}", sources);
-
-        let expected = [DataSourceInfo {
-                            server_name: "PostgreSQL".to_owned(),
-                            description: "PostgerSQL Unicode".to_owned(),
+                            description: "PostgreSQL Unicode".to_owned(),
                         }];
         assert!(sources.iter().eq(expected.iter()));
     }
@@ -59,6 +44,21 @@ mod test {
         let environment = Environment::new();
         let sources = environment.expect("Environment can be created")
             .user_data_sources()
+            .expect("Data sources can be iterated over");
+        println!("{:?}", sources);
+
+        let expected = [DataSourceInfo {
+                            server_name: "PostgreSQL".to_owned(),
+                            description: "PostgreSQL Unicode".to_owned(),
+                        }];
+        assert!(sources.iter().eq(expected.iter()));
+    }
+
+    #[test]
+    fn list_system_data_sources() {
+        let environment = Environment::new();
+        let sources = environment.expect("Environment can be created")
+            .system_data_sources()
             .expect("Data sources can be iterated over");
         println!("{:?}", sources);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,30 @@ mod test {
 
         let expected: [String; 0] = [];
         assert!(sources.iter().map(|d| &d.server_name).eq(expected.iter()));
-        assert!(false);
+    }
+
+    #[test]
+    fn list_system_data_sources() {
+        let environment = Environment::new();
+        let sources = environment.expect("Environment can be created")
+            .system_data_sources()
+            .expect("Data sources can be iterated over");
+        println!("{:?}", sources);
+
+        let expected: [String; 0] = [];
+        assert!(sources.iter().map(|d| &d.server_name).eq(expected.iter()));
+    }
+
+    #[test]
+    fn list_user_data_sources() {
+        let environment = Environment::new();
+        let sources = environment.expect("Environment can be created")
+            .user_data_sources()
+            .expect("Data sources can be iterated over");
+        println!("{:?}", sources);
+
+        let expected: [String; 0] = [];
+        assert!(sources.iter().map(|d| &d.server_name).eq(expected.iter()));
     }
 
     #[test]

--- a/travis/odbc.ini
+++ b/travis/odbc.ini
@@ -1,0 +1,5 @@
+[PostgreSQL]
+Driver              = PostgreSQL Unicode
+Database            = travis_ci_database
+Servername          = localhost
+UserName            = postgres


### PR DESCRIPTION
added three methods to `Environment`: `system_data_sources`, `user_data_sources` and `data_sources` which list system, user or all data sources. To avoid code repetition, some of the code of `Environment::drivers` has been moved into helper methods. Looking forward to your feedback!