### PR TITLE
Introduce generic Raii struct to handle allocation and deallocation of handles

### DIFF
--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -82,11 +82,6 @@ impl<'a> DataSource<'a> {
             }
         }
     }
-
-    /// Allows access to the raw ODBC handle
-    pub unsafe fn raw(&mut self) -> ffi::SQLHDBC {
-        self.raii.handle()
-    }
 }
 
 impl<'a> Handle for DataSource<'a> {

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -1,6 +1,5 @@
 //! Holds implementation of odbc connection
-use super::{ffi, Environment, Result, Error, GetDiagRec};
-use safe::{Handle};
+use super::{ffi, Environment, Result, Error, GetDiagRec, Handle};
 use super::ffi::SQLRETURN::*;
 use std;
 use std::marker::PhantomData;
@@ -14,6 +13,7 @@ pub struct DataSource<'a> {
 }
 
 impl<'a> DataSource<'a> {
+
     /// Connects to an ODBC data source
     ///
     /// # Arguments
@@ -99,20 +99,17 @@ impl<'a> DataSource<'a> {
     }
 }
 
-unsafe impl<'a> Handle for DataSource<'a> {
-    fn handle(&self) -> ffi::SQLHANDLE {
-        self.handle as ffi::SQLHANDLE
-    }
-
-    fn handle_type() -> ffi::HandleType {
-        ffi::SQL_HANDLE_DBC
+impl<'a> Handle for DataSource<'a> {
+    type To = ffi::Dbc;
+    unsafe fn handle(&self) -> ffi::SQLHDBC {
+        self.handle
     }
 }
 
 impl<'a> Drop for DataSource<'a> {
     fn drop(&mut self) {
         unsafe {
-            ffi::SQLFreeHandle(ffi::SQL_HANDLE_DBC, self.handle());
+            ffi::SQLFreeHandle(ffi::SQL_HANDLE_DBC, self.handle() as ffi::SQLHANDLE);
         }
     }
 }

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -1,19 +1,18 @@
 //! Holds implementation of odbc connection
-use super::{ffi, Environment, Result, Error, GetDiagRec, Handle};
+use super::{ffi, Environment, Return, Result, Raii, Error, GetDiagRec, Handle};
 use super::ffi::SQLRETURN::*;
 use std;
 use std::marker::PhantomData;
 
 /// Represents a connection to an ODBC data source
 pub struct DataSource<'a> {
-    handle: ffi::SQLHDBC,
+    raii: Raii<ffi::Dbc>,
     // we use phantom data to tell the borrow checker that we need to keep the environment alive for
     // the lifetime of the connection
-    env: PhantomData<&'a Environment>,
+    parent: PhantomData<&'a Environment>,
 }
 
 impl<'a> DataSource<'a> {
-
     /// Connects to an ODBC data source
     ///
     /// # Arguments
@@ -26,10 +25,19 @@ impl<'a> DataSource<'a> {
                                         usr: &str,
                                         pwd: &str)
                                         -> Result<DataSource<'b>> {
-        let data_source = Self::allocate(env)?;
+        let raii = match Raii::with_parent(env) {
+            Return::Success(dbc) => dbc,
+            Return::SuccessWithInfo(dbc) => dbc,
+            Return::Error => return Err(Error::SqlError(env.get_diag_rec(1).unwrap())),
+        };
+
+        let data_source = DataSource {
+            raii: raii,
+            parent: PhantomData,
+        };
 
         unsafe {
-            match ffi::SQLConnect(data_source.handle,
+            match ffi::SQLConnect(data_source.handle(),
                                   dsn.as_ptr(),
                                   dsn.as_bytes().len() as ffi::SQLSMALLINT,
                                   usr.as_ptr(),
@@ -53,7 +61,7 @@ impl<'a> DataSource<'a> {
         let mut buffer: [u8; 2] = [0; 2];
 
         unsafe {
-            match ffi::SQLGetInfo(self.handle,
+            match ffi::SQLGetInfo(self.raii.handle(),
                                   ffi::SQL_DATA_SOURCE_READ_ONLY,
                                   buffer.as_mut_ptr() as *mut std::os::raw::c_void,
                                   buffer.len() as ffi::SQLSMALLINT,
@@ -77,40 +85,14 @@ impl<'a> DataSource<'a> {
 
     /// Allows access to the raw ODBC handle
     pub unsafe fn raw(&mut self) -> ffi::SQLHDBC {
-        self.handle
-    }
-
-    fn allocate(env: &mut Environment) -> Result<DataSource> {
-        unsafe {
-            let mut conn = std::ptr::null_mut();
-            match ffi::SQLAllocHandle(ffi::SQL_HANDLE_DBC, env.raw() as ffi::SQLHANDLE, &mut conn) {
-                SQL_SUCCESS |
-                SQL_SUCCESS_WITH_INFO => {
-                    Ok(DataSource {
-                           handle: conn as ffi::SQLHDBC,
-                           env: PhantomData,
-                       })
-                }
-                // Driver Manager failed to allocate environment
-                SQL_ERROR => Err(Error::SqlError(env.get_diag_rec(1).unwrap())),
-                _ => unreachable!(),
-            }
-        }
+        self.raii.handle()
     }
 }
 
 impl<'a> Handle for DataSource<'a> {
     type To = ffi::Dbc;
     unsafe fn handle(&self) -> ffi::SQLHDBC {
-        self.handle
-    }
-}
-
-impl<'a> Drop for DataSource<'a> {
-    fn drop(&mut self) {
-        unsafe {
-            ffi::SQLFreeHandle(ffi::SQL_HANDLE_DBC, self.handle() as ffi::SQLHANDLE);
-        }
+        self.raii.handle()
     }
 }
 

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -1,6 +1,6 @@
 //! Holds implementation of odbc connection
-use super::{ffi, Environment, Result, Error};
-use safe::{Handle, GetDiagRec};
+use super::{ffi, Environment, Result, Error, GetDiagRec};
+use safe::{Handle};
 use super::ffi::SQLRETURN::*;
 use std;
 use std::marker::PhantomData;
@@ -38,7 +38,7 @@ impl<'a> DataSource<'a> {
                                   pwd.as_bytes().len() as ffi::SQLSMALLINT) {
                 SQL_SUCCESS |
                 SQL_SUCCESS_WITH_INFO => Ok(data_source),
-                _ => Err(Error::SqlError(data_source.get_diagnostic_record(1).unwrap())),
+                _ => Err(Error::SqlError(data_source.get_diag_rec(1).unwrap())),
             }
         }
     }
@@ -69,7 +69,7 @@ impl<'a> DataSource<'a> {
                            }
                        })
                 }
-                SQL_ERROR => Err(Error::SqlError(self.get_diagnostic_record(1).unwrap())),
+                SQL_ERROR => Err(Error::SqlError(self.get_diag_rec(1).unwrap())),
                 _ => unreachable!(),
             }
         }
@@ -92,7 +92,7 @@ impl<'a> DataSource<'a> {
                        })
                 }
                 // Driver Manager failed to allocate environment
-                SQL_ERROR => Err(Error::SqlError(env.get_diagnostic_record(1).unwrap())),
+                SQL_ERROR => Err(Error::SqlError(env.get_diag_rec(1).unwrap())),
                 _ => unreachable!(),
             }
         }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -147,11 +147,6 @@ impl Environment {
         Ok(source_list)
     }
 
-    /// Allows access to the raw ODBC handle
-    pub unsafe fn raw(&mut self) -> ffi::SQLHENV {
-        self.handle.borrow().handle()
-    }
-
     /// Calls either SQLDrivers or SQLDataSources with the two given buffers and parses the result
     /// into a `(&str,&str)`
     fn get_info<'a, 'b>(&self,

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,5 +1,5 @@
 //! This module implements the ODBC Environment
-use super::{Error, Result, Return, ffi, GetDiagRec, DiagnosticRecord, Raii, Handle};
+use super::{Error, Result, Return, ffi, GetDiagRec, Raii, Handle};
 use super::safe;
 use std::collections::HashMap;
 use std::cell::RefCell;
@@ -12,9 +12,10 @@ pub struct Environment {
     handle: RefCell<Raii<ffi::Env>>,
 }
 
-impl GetDiagRec for Environment {
-    fn get_diag_rec(&self, record_number: i16) -> Option<DiagnosticRecord> {
-        self.handle.borrow().get_diag_rec(record_number)
+impl Handle for Environment {
+    type To = ffi::Env;
+    unsafe fn handle(&self) -> ffi::SQLHENV {
+        self.handle.borrow().handle()
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,14 +1,14 @@
 //! Implements Error type. It implements the `std::error::Error` for errors returned by ODBC and
 //! allows for an error handling which his idomatic to rust
 
-pub use safe::DiagRec;
+pub use super::DiagnosticRecord;
 use std::fmt::{Display, Formatter};
 use std;
 
 /// An ODBC Error
 #[derive(Debug)]
 pub enum Error {
-    SqlError(DiagRec),
+    SqlError(DiagnosticRecord),
     EnvAllocFailure,
 }
 
@@ -40,7 +40,7 @@ mod test {
     #[test]
     fn format_error() {
 
-        let error = Error::SqlError(DiagRec {
+        let error = Error::SqlError(DiagnosticRecord {
             state: [72, 89, 48, 48, 57, 0],
             native_error_pointer: 0,
             message: "[Microsoft][ODBC Driver Manager] Invalid argument value".to_owned(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,15 @@ use raii::Raii;
 pub use diagnostics::{DiagnosticRecord, GetDiagRec};
 pub use error::*;
 pub use environment::*;
-pub use data_source::*;
+pub use data_source::DataSource;
 pub use statement::*;
+
+/// Reflects the ability of a type to expose a valid handle
+pub trait Handle{
+    type To;
+    /// Returns a valid handle to the odbc type.
+    unsafe fn handle(&self) -> * mut Self::To;
+}
 
 #[must_use]
 pub enum Return<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,12 @@ mod test {
         let mut env = Environment::new().unwrap();
         let mut ds = DataSource::with_dsn_and_credentials(&mut env, "PostgreSQL", "postgres", "")
             .unwrap();
-        let statement = Statement::with_tables(&mut ds).unwrap();
-        assert_eq!(statement.num_result_cols().unwrap(), 5);
+        // scope is required (for now) to close statement before disconnecting
+        {
+            let statement = Statement::with_tables(&mut ds).unwrap();
+            assert_eq!(statement.num_result_cols().unwrap(), 5);
+        }
+        ds.disconnect().unwrap();
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,11 +54,12 @@ mod test {
     fn test_connection() {
 
         let mut environment = Environment::new().expect("Environment can be created");
-        let conn =
+        let mut conn =
             DataSource::with_dsn_and_credentials(&mut environment, "PostgreSQL", "postgres", "")
                 .expect("Could not connect");
 
         assert!(!conn.read_only().unwrap());
+        conn.disconnect().unwrap();
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,26 @@
 pub mod ffi;
-
+mod odbc_object;
+mod raii;
+mod diagnostics;
 mod safe;
 mod error;
-pub use error::*;
 mod environment;
-pub use environment::*;
 mod data_source;
-pub use data_source::*;
 mod statement;
+use odbc_object::OdbcObject;
+use raii::Raii;
+pub use diagnostics::{DiagnosticRecord, GetDiagRec};
+pub use error::*;
+pub use environment::*;
+pub use data_source::*;
 pub use statement::*;
+
+#[must_use]
+pub enum Return<T> {
+    Success(T),
+    SuccessWithInfo(T),
+    Error,
+}
 
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/src/odbc_object.rs
+++ b/src/odbc_object.rs
@@ -1,0 +1,29 @@
+use ffi;
+
+/// Trait to be implemented by all opaque types which are referenced by handles in the ffi layer
+pub unsafe trait OdbcObject {
+    type Parent;
+    fn handle_type() -> ffi::HandleType;
+}
+
+unsafe impl OdbcObject for ffi::Env {
+    type Parent = ();
+    fn handle_type() -> ffi::HandleType {
+        ffi::SQL_HANDLE_ENV
+    }
+}
+
+unsafe impl OdbcObject for ffi::Dbc {
+    type Parent = ffi::Env;
+    fn handle_type() -> ffi::HandleType {
+        ffi::SQL_HANDLE_DBC
+    }
+}
+
+unsafe impl OdbcObject for ffi::Stmt {
+    type Parent = ffi::Dbc;
+    fn handle_type() -> ffi::HandleType {
+        ffi::SQL_HANDLE_STMT
+    }
+}
+

--- a/src/raii.rs
+++ b/src/raii.rs
@@ -1,0 +1,61 @@
+use super::{ffi, OdbcObject, GetDiagRec, Return};
+use std::ptr::null_mut;
+
+/// Wrapper around handle types which ensures the wrapped value is always valid.
+///
+/// Resource Acquisition Is Initialization
+pub struct Raii<T: OdbcObject> {
+    //Invariant: Should always point to a valid odbc Object
+    handle: *mut T,
+}
+
+impl<T: OdbcObject> Raii<T> {
+    // pub fn with_parent(parent: &Raii<T::Parent>) -> Return<Self>
+    //     where T::Parent: OdbcObject
+    // {
+    //     let mut handle: ffi::SQLHANDLE = null_mut();
+    //     match unsafe {
+    //               ffi::SQLAllocHandle(T::handle_type(),
+    //                                   parent.handle() as ffi::SQLHANDLE,
+    //                                   &mut handle as *mut ffi::SQLHANDLE)
+    //           } {
+    //         ffi::SQL_SUCCESS => Return::Success(Raii { handle: handle as *mut T }),
+    //         ffi::SQL_SUCCESS_WITH_INFO => {
+    //             Return::SuccessWithInfo(Raii { handle: handle as *mut T })
+    //         }
+    //         ffi::SQL_ERROR => Return::Error,
+    //         _ => panic!("SQLAllocHandle returned unexpected result"),
+    //     }
+    // }
+
+    pub unsafe fn handle(&self) -> *mut T {
+        self.handle
+    }
+}
+
+impl Raii<ffi::Env> {
+    pub unsafe fn new() -> Return<Self> {
+        let mut handle: ffi::SQLHANDLE = null_mut();
+        match ffi::SQLAllocHandle(ffi::Env::handle_type(),
+                                  null_mut(),
+                                  &mut handle as *mut ffi::SQLHANDLE) {
+            ffi::SQL_SUCCESS => Return::Success(Raii { handle: handle as ffi::SQLHENV }),
+            ffi::SQL_SUCCESS_WITH_INFO => {
+                Return::SuccessWithInfo(Raii { handle: handle as ffi::SQLHENV })
+            }
+            ffi::SQL_ERROR => Return::Error,
+            _ => panic!("SQLAllocHandle returned unexpected result"),
+        }
+    }
+}
+
+impl<T: OdbcObject> Drop for Raii<T> {
+    fn drop(&mut self) {
+        match unsafe { ffi::SQLFreeHandle(T::handle_type(), self.handle() as ffi::SQLHANDLE) } {
+            ffi::SQL_SUCCESS => (),
+            ffi::SQL_ERROR => panic!("Error freeing handle: {}", self.get_diag_rec(1).unwrap()),
+            _ => panic!("Unexepected return value of SQLFreeHandle"),
+        }
+    }
+}
+

--- a/src/raii.rs
+++ b/src/raii.rs
@@ -27,23 +27,23 @@ impl<T: OdbcObject> Drop for Raii<T> {
 }
 
 impl<T: OdbcObject> Raii<T> {
-    // pub fn with_parent(parent: &Raii<T::Parent>) -> Return<Self>
-    //     where T::Parent: OdbcObject
-    // {
-    //     let mut handle: ffi::SQLHANDLE = null_mut();
-    //     match unsafe {
-    //               ffi::SQLAllocHandle(T::handle_type(),
-    //                                   parent.handle() as ffi::SQLHANDLE,
-    //                                   &mut handle as *mut ffi::SQLHANDLE)
-    //           } {
-    //         ffi::SQL_SUCCESS => Return::Success(Raii { handle: handle as *mut T }),
-    //         ffi::SQL_SUCCESS_WITH_INFO => {
-    //             Return::SuccessWithInfo(Raii { handle: handle as *mut T })
-    //         }
-    //         ffi::SQL_ERROR => Return::Error,
-    //         _ => panic!("SQLAllocHandle returned unexpected result"),
-    //     }
-    // }
+    pub fn with_parent<P>(parent: &P) -> Return<Self>
+        where P: Handle<To = T::Parent>
+    {
+        let mut handle: ffi::SQLHANDLE = null_mut();
+        match unsafe {
+                  ffi::SQLAllocHandle(T::handle_type(),
+                                      parent.handle() as ffi::SQLHANDLE,
+                                      &mut handle as *mut ffi::SQLHANDLE)
+              } {
+            ffi::SQL_SUCCESS => Return::Success(Raii { handle: handle as *mut T }),
+            ffi::SQL_SUCCESS_WITH_INFO => {
+                Return::SuccessWithInfo(Raii { handle: handle as *mut T })
+            }
+            ffi::SQL_ERROR => Return::Error,
+            _ => panic!("SQLAllocHandle returned unexpected result"),
+        }
+    }
 }
 
 impl Raii<ffi::Env> {

--- a/src/safe/environment.rs
+++ b/src/safe/environment.rs
@@ -1,18 +1,10 @@
-use super::{as_buffer_length, as_out_buffer, Handle};
-use super::super::{ffi, Raii};
-use ffi::{SQLAllocHandle, SQLFreeHandle, SQLSetEnvAttr, SQLDataSources, SQLDrivers, HandleType,
-          SQLRETURN, SQLHENV, SQLHANDLE, SQLSMALLINT, SQLCHAR, SQL_HANDLE_ENV,
+use super::{as_buffer_length, as_out_buffer};
+use super::super::{ffi, Raii, Handle};
+use ffi::{SQLSetEnvAttr, SQLDataSources, SQLDrivers, SQLRETURN, SQLHENV, SQLSMALLINT, SQLCHAR,
           SQL_ATTR_ODBC_VERSION, SQL_OV_ODBC3, FetchOrientation};
-use std::ptr::null_mut;
 use std::os::raw::c_void;
 
-/// Safe wrapper around ODBC Environment handle
-pub type Environment = Raii<ffi::Env>;
-// pub struct Environment {
-//     handle: SQLHENV,
-// }
-
-impl Environment {
+impl Raii<ffi::Env> {
     pub fn set_odbc_version_3(&mut self) -> SetEnvAttrResult {
 
         use self::SetEnvAttrResult::*;

--- a/src/safe/environment.rs
+++ b/src/safe/environment.rs
@@ -1,4 +1,5 @@
 use super::{as_buffer_length, as_out_buffer, Handle};
+use super::super::{ffi, Raii};
 use ffi::{SQLAllocHandle, SQLFreeHandle, SQLSetEnvAttr, SQLDataSources, SQLDrivers, HandleType,
           SQLRETURN, SQLHENV, SQLHANDLE, SQLSMALLINT, SQLCHAR, SQL_HANDLE_ENV,
           SQL_ATTR_ODBC_VERSION, SQL_OV_ODBC3, FetchOrientation};
@@ -6,50 +7,18 @@ use std::ptr::null_mut;
 use std::os::raw::c_void;
 
 /// Safe wrapper around ODBC Environment handle
-pub struct Environment {
-    handle: SQLHENV,
-}
-
-impl Drop for Environment {
-    fn drop(&mut self) {
-        unsafe {
-            SQLFreeHandle(SQL_HANDLE_ENV, self.handle as SQLHANDLE);
-        }
-    }
-}
-
-unsafe impl Handle for Environment {
-    fn handle(&self) -> SQLHANDLE {
-        self.handle as SQLHANDLE
-    }
-
-    fn handle_type() -> HandleType {
-        SQL_HANDLE_ENV
-    }
-}
+pub type Environment = Raii<ffi::Env>;
+// pub struct Environment {
+//     handle: SQLHENV,
+// }
 
 impl Environment {
-    pub fn new() -> EnvAllocResult {
-
-        use self::EnvAllocResult::*;
-
-        let mut env = null_mut();
-        match unsafe { SQLAllocHandle(SQL_HANDLE_ENV, null_mut(), &mut env) } {
-            SQLRETURN::SQL_SUCCESS => Success(Environment { handle: env as SQLHENV }),
-            SQLRETURN::SQL_SUCCESS_WITH_INFO => {
-                SuccessWithInfo(Environment { handle: env as SQLHENV })
-            }
-            SQLRETURN::SQL_ERROR => Error,
-            _ => panic!("SQLAllocHandle returned an unexpected result"),
-        }
-    }
-
     pub fn set_odbc_version_3(&mut self) -> SetEnvAttrResult {
 
         use self::SetEnvAttrResult::*;
 
         match unsafe {
-                  SQLSetEnvAttr(self.handle,
+                  SQLSetEnvAttr(self.handle(),
                                 SQL_ATTR_ODBC_VERSION,
                                 SQL_OV_ODBC3 as *mut c_void,
                                 0)
@@ -97,7 +66,7 @@ impl Environment {
                          -> IterationResult<(i16, i16)> {
         let (mut server_name_length, mut description_length): (i16, i16) = (0, 0);
         match unsafe {
-                  c_function(self.handle,
+                  c_function(self.handle(),
                              direction,
                              as_out_buffer(server_name),
                              as_buffer_length(server_name.len()),
@@ -135,17 +104,6 @@ pub enum IterationResult<T> {
     Success(T),
     SuccessWithInfo(T),
     NoData,
-    Error,
-}
-
-/// Returned if an Environment is allocated
-#[must_use]
-pub enum EnvAllocResult {
-    /// Creation of the environment is a success
-    Success(Environment),
-    /// Successfully created environment with warnings
-    SuccessWithInfo(Environment),
-    /// Allocation failed
     Error,
 }
 

--- a/src/safe/mod.rs
+++ b/src/safe/mod.rs
@@ -2,14 +2,12 @@
 //! race conditions. It's main purpose is not to provide direct value to the crate user, but to
 //! enable the layers on top of it to be written in safe code.
 
-mod diagnostics;
 mod environment;
-pub use self::diagnostics::*;
 pub use self::environment::*;
 
 use std;
-
 use ffi::{SQLSMALLINT, SQLHANDLE, HandleType};
+use super::{OdbcObject, Raii};
 
 fn as_out_buffer(buffer: &mut [u8]) -> *mut u8 {
     if buffer.len() == 0 {
@@ -31,4 +29,14 @@ fn as_buffer_length(n: usize) -> SQLSMALLINT {
 pub unsafe trait Handle {
     fn handle(&self) -> SQLHANDLE;
     fn handle_type() -> HandleType;
+}
+
+unsafe impl<T : OdbcObject> Handle for Raii<T>{
+    fn handle(&self) -> SQLHANDLE{
+        unsafe {self.handle() as SQLHANDLE}
+    }
+
+    fn handle_type() -> HandleType{
+        T::handle_type()
+    }
 }

--- a/src/safe/mod.rs
+++ b/src/safe/mod.rs
@@ -25,18 +25,3 @@ fn as_buffer_length(n: usize) -> SQLSMALLINT {
         n as i16
     }
 }
-
-pub unsafe trait Handle {
-    fn handle(&self) -> SQLHANDLE;
-    fn handle_type() -> HandleType;
-}
-
-unsafe impl<T : OdbcObject> Handle for Raii<T>{
-    fn handle(&self) -> SQLHANDLE{
-        unsafe {self.handle() as SQLHANDLE}
-    }
-
-    fn handle_type() -> HandleType{
-        T::handle_type()
-    }
-}

--- a/src/safe/mod.rs
+++ b/src/safe/mod.rs
@@ -6,8 +6,7 @@ mod environment;
 pub use self::environment::*;
 
 use std;
-use ffi::{SQLSMALLINT, SQLHANDLE, HandleType};
-use super::{OdbcObject, Raii};
+use ffi::SQLSMALLINT;
 
 fn as_out_buffer(buffer: &mut [u8]) -> *mut u8 {
     if buffer.len() == 0 {

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -1,6 +1,6 @@
 
-use super::{ffi, DataSource, Error, Result};
-use safe::{Handle, GetDiagRec};
+use super::{ffi, DataSource, Error, Result, GetDiagRec};
+use safe::Handle;
 use super::ffi::SQLRETURN::*;
 use std::marker::PhantomData;
 use std::ptr::null_mut;
@@ -50,7 +50,7 @@ impl<'a> Statement<'a> {
                                  table_type.as_bytes().len() as ffi::SQLSMALLINT) {
                 SQL_SUCCESS |
                 SQL_SUCCESS_WITH_INFO => Ok(stmt),
-                SQL_ERROR => Err(Error::SqlError(stmt.get_diagnostic_record(1).unwrap())),
+                SQL_ERROR => Err(Error::SqlError(stmt.get_diag_rec(1).unwrap())),
                 SQL_STILL_EXECUTING => panic!("Multithreading currently impossible in safe code"),
                 _ => unreachable!(),
             }
@@ -71,7 +71,7 @@ impl<'a> Statement<'a> {
                        })
                 }
                 // Driver Manager failed to allocate statement
-                SQL_ERROR => Err(Error::SqlError(parent.get_diagnostic_record(1).unwrap())),
+                SQL_ERROR => Err(Error::SqlError(parent.get_diag_rec(1).unwrap())),
                 _ => unreachable!(),
             }
         }
@@ -87,7 +87,7 @@ impl<'a> Statement<'a> {
             match ffi::SQLNumResultCols(self.handle, &mut num_cols as *mut ffi::SQLSMALLINT) {
                 SQL_SUCCESS |
                 SQL_SUCCESS_WITH_INFO => Ok(num_cols),
-                SQL_ERROR => Err(Error::SqlError(self.get_diagnostic_record(1).unwrap())),
+                SQL_ERROR => Err(Error::SqlError(self.get_diag_rec(1).unwrap())),
                 SQL_STILL_EXECUTING => panic!("Multithreading currently impossible in safe code"),
                 _ => unreachable!(),
             }

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -1,6 +1,5 @@
 
-use super::{ffi, DataSource, Error, Result, GetDiagRec};
-use safe::Handle;
+use super::{ffi, DataSource, Error, Result, GetDiagRec, Handle};
 use super::ffi::SQLRETURN::*;
 use std::marker::PhantomData;
 use std::ptr::null_mut;
@@ -21,13 +20,10 @@ impl<'a> Drop for Statement<'a> {
     }
 }
 
-unsafe impl<'a> Handle for Statement<'a> {
-    fn handle(&self) -> ffi::SQLHANDLE {
-        self.handle as ffi::SQLHANDLE
-    }
-
-    fn handle_type() -> ffi::HandleType {
-        ffi::SQL_HANDLE_STMT
+impl<'a> Handle for Statement<'a> {
+    type To = ffi::Stmt;
+    unsafe fn handle(&self) -> ffi::SQLHSTMT {
+        self.handle
     }
 }
 

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -1,41 +1,42 @@
 
-use super::{ffi, DataSource, Error, Result, GetDiagRec, Handle};
+use super::{ffi, DataSource, Error, Return, Result, Raii, GetDiagRec, Handle};
 use super::ffi::SQLRETURN::*;
 use std::marker::PhantomData;
-use std::ptr::null_mut;
 
 /// RAII wrapper around ODBC statement
 pub struct Statement<'a> {
-    handle: ffi::SQLHSTMT,
+    raii: Raii<ffi::Stmt>,
     // we use phantom data to tell the borrow checker that we need to keep the data source alive
     // for the lifetime of the statement
     parent: PhantomData<&'a DataSource<'a>>,
 }
 
-impl<'a> Drop for Statement<'a> {
-    fn drop(&mut self) {
-        unsafe {
-            ffi::SQLFreeHandle(ffi::SQL_HANDLE_STMT, self.handle as ffi::SQLHANDLE);
-        }
-    }
-}
-
 impl<'a> Handle for Statement<'a> {
     type To = ffi::Stmt;
     unsafe fn handle(&self) -> ffi::SQLHSTMT {
-        self.handle
+        self.raii.handle()
     }
 }
 
 impl<'a> Statement<'a> {
     pub fn with_tables<'b>(ds: &'b mut DataSource) -> Result<Statement<'b>> {
-        let stmt = Statement::allocate(ds)?;
+        let raii = match Raii::with_parent(ds) {
+            Return::Success(s) => s,
+            Return::SuccessWithInfo(s) => s,
+            Return::Error => return Err(Error::SqlError(ds.get_diag_rec(1).unwrap())),
+        };
+
+        let stmt = Statement {
+            raii: raii,
+            parent: PhantomData,
+        };
+
         let catalog_name = "";
         let schema_name = "";
         let table_name = "";
         let table_type = "TABLE";
         unsafe {
-            match ffi::SQLTables(stmt.handle,
+            match ffi::SQLTables(stmt.raii.handle(),
                                  catalog_name.as_ptr(),
                                  catalog_name.as_bytes().len() as ffi::SQLSMALLINT,
                                  schema_name.as_ptr(),
@@ -53,26 +54,6 @@ impl<'a> Statement<'a> {
         }
     }
 
-    fn allocate<'b>(parent: &'b mut DataSource) -> Result<Statement<'b>> {
-        unsafe {
-            let mut stmt = null_mut();
-            match ffi::SQLAllocHandle(ffi::SQL_HANDLE_STMT,
-                                      parent.raw() as ffi::SQLHANDLE,
-                                      &mut stmt) {
-                SQL_SUCCESS |
-                SQL_SUCCESS_WITH_INFO => {
-                    Ok(Statement {
-                           handle: stmt as ffi::SQLHSTMT,
-                           parent: PhantomData,
-                       })
-                }
-                // Driver Manager failed to allocate statement
-                SQL_ERROR => Err(Error::SqlError(parent.get_diag_rec(1).unwrap())),
-                _ => unreachable!(),
-            }
-        }
-    }
-
     /// The number of columns in a result set
     ///
     /// Can be called successfully only when the statement is in the prepared, executed, or
@@ -80,7 +61,8 @@ impl<'a> Statement<'a> {
     pub fn num_result_cols(&self) -> Result<i16> {
         let mut num_cols: ffi::SQLSMALLINT = 0;
         unsafe {
-            match ffi::SQLNumResultCols(self.handle, &mut num_cols as *mut ffi::SQLSMALLINT) {
+            match ffi::SQLNumResultCols(self.raii.handle(),
+                                        &mut num_cols as *mut ffi::SQLSMALLINT) {
                 SQL_SUCCESS |
                 SQL_SUCCESS_WITH_INFO => Ok(num_cols),
                 SQL_ERROR => Err(Error::SqlError(self.get_diag_rec(1).unwrap())),
@@ -88,11 +70,6 @@ impl<'a> Statement<'a> {
                 _ => unreachable!(),
             }
         }
-    }
-
-    /// Allows access to the raw ODBC handle
-    pub unsafe fn raw(&mut self) -> ffi::SQLHSTMT {
-        self.handle
     }
 }
 


### PR DESCRIPTION
* Results of `SQLFreeHandle` is now always evaluated.
* This showed that two test cases were in fact broken. Added `disconnect` method to `data_source` in order to fix them