### PR TITLE
Binding of parameters in safe code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "odbc"
-description = "ODBC FFI binding for Rust"
+description = "ODBC wrapper for idiomatic Rust"
 version = "0.4.1"
 authors = ["Konstantin Salikhov <koka58@yandex.ru>"]
 repository = "https://github.com/Koka/odbc-rs"
 documentation = "http://koka.github.io/odbc-rs/odbc/"
 homepage = "https://github.com/Koka/odbc-rs"
 readme = "README.md"
-keywords = ["odbc", "binding", "ffi", "database", "db"]
+keywords = ["odbc", "binding", "sql", "database", "db"]
 license = "MIT"
 categories = ["api-bindings", "database"]
 
 [dependencies]
-odbc-sys = "0.2.5"
+odbc-sys = "0.2.6"
 log = "0.3.7"
 
 [dev-dependencies]

--- a/examples/connect.rs
+++ b/examples/connect.rs
@@ -54,4 +54,3 @@ fn execute_statement(mut conn: &mut DataSource<Connected>) -> Result<()> {
 
     Ok(())
 }
-

--- a/src/environment/list_data_sources.rs
+++ b/src/environment/list_data_sources.rs
@@ -38,11 +38,11 @@ impl Environment<Version3> {
         attributes.split('\0')
             .take_while(|kv_str| *kv_str != String::new())
             .map(|kv_str| {
-                     let mut iter = kv_str.split('=');
-                     let key = iter.next().unwrap();
-                     let value = iter.next().unwrap();
-                     (key.to_string(), value.to_string())
-                 })
+                let mut iter = kv_str.split('=');
+                let key = iter.next().unwrap();
+                let value = iter.next().unwrap();
+                (key.to_string(), value.to_string())
+            })
             .collect()
     }
 
@@ -63,9 +63,9 @@ impl Environment<Version3> {
                           &mut description_buffer,
                           &mut attribute_buffer)? {
             driver_list.push(DriverInfo {
-                                 description: desc.to_owned(),
-                                 attributes: Self::parse_attributes(attr),
-                             })
+                description: desc.to_owned(),
+                attributes: Self::parse_attributes(attr),
+            })
         }
         Ok(driver_list)
     }
@@ -105,9 +105,9 @@ impl Environment<Version3> {
                           &mut name_buffer,
                           &mut description_buffer)? {
             source_list.push(DataSourceInfo {
-                                 server_name: name.to_owned(),
-                                 driver: desc.to_owned(),
-                             })
+                server_name: name.to_owned(),
+                driver: desc.to_owned(),
+            })
         } else {
             return Ok(source_list);
         }
@@ -118,9 +118,9 @@ impl Environment<Version3> {
                           &mut name_buffer,
                           &mut description_buffer)? {
             source_list.push(DataSourceInfo {
-                                 server_name: name.to_owned(),
-                                 driver: desc.to_owned(),
-                             })
+                server_name: name.to_owned(),
+                driver: desc.to_owned(),
+            })
         }
         Ok(source_list)
     }
@@ -222,15 +222,15 @@ impl Raii<ffi::Env> {
                          -> Return<Option<(i16, i16)>> {
         let (mut server_name_length, mut description_length): (i16, i16) = (0, 0);
         match unsafe {
-                  c_function(self.handle(),
-                             direction,
-                             as_out_buffer(server_name),
-                             as_buffer_length(server_name.len()),
-                             &mut server_name_length as *mut i16,
-                             as_out_buffer(description),
-                             as_buffer_length(description.len()),
-                             &mut description_length as *mut i16)
-              } {
+            c_function(self.handle(),
+                       direction,
+                       as_out_buffer(server_name),
+                       as_buffer_length(server_name.len()),
+                       &mut server_name_length as *mut i16,
+                       as_out_buffer(description),
+                       as_buffer_length(description.len()),
+                       &mut description_length as *mut i16)
+        } {
             SQLRETURN::SQL_SUCCESS => {
                 Return::Success(Some((server_name_length, description_length)))
             }
@@ -274,4 +274,3 @@ mod test {
         assert_eq!(attributes["UsageCount"], "1");
     }
 }
-

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -65,6 +65,18 @@ impl Environment<NoVersion> {
     }
 
     /// Tells the driver(s) that we will use features of up to ODBC version 3
+    ///
+    /// The first thing to do with an ODBC `Environment` is to set a version.
+    ///
+    /// # Example
+    /// ```
+    /// fn do_database_stuff() -> std::result::Result<(), Box<std::error::Error>> {
+    ///     use odbc::*;
+    ///     let env = Environment::new()?.set_odbc_version_3()?; // first thing to do
+    ///     // ...
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_odbc_version_3(mut self) -> Result<Environment<Version3>> {
         self.raii.set_odbc_version_3().into_result(&self)?;
         Ok(Environment {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,4 +1,3 @@
 //! Reexport odbc-sys as ffi
 extern crate odbc_sys;
 pub use self::odbc_sys::*;
-

--- a/src/result.rs
+++ b/src/result.rs
@@ -64,4 +64,3 @@ impl std::error::Error for EnvAllocError {
         None
     }
 }
-

--- a/src/statement/bind_parameter.rs
+++ b/src/statement/bind_parameter.rs
@@ -9,11 +9,16 @@ pub unsafe trait InputParameter {
     fn indicator(&self) -> ffi::SQLLEN;
 }
 
-impl<'a, S> Statement<'a, S> {
-    pub fn bind_parameter<T>(&mut self, parameter_index: u16, value: &T) -> Result<()>
-        where T: InputParameter
+impl<'a, 'b, S> Statement<'a, 'b, S> {
+    pub fn bind_parameter<'c, T>(mut self,
+                                 parameter_index: u16,
+                                 value: &'c T)
+                                 -> Result<Statement<'a, 'c, S>>
+        where T: InputParameter,
+              'b: 'c
     {
-        self.raii.bind_input_parameter(parameter_index, value).into_result(self)
+        self.raii.bind_input_parameter(parameter_index, value).into_result(&self)?;
+        Ok(self)
     }
 }
 

--- a/src/statement/bind_parameter.rs
+++ b/src/statement/bind_parameter.rs
@@ -1,0 +1,43 @@
+use {ffi, Return, Result, Raii, Handle, Statement};
+
+/// Allows types to be used with `Statement::bind_parameter`
+pub unsafe trait InputParameter {
+    fn c_data_type(&self) -> ffi::SqlCDataType;
+    fn column_size(&self) -> ffi::SQLULEN;
+    fn decimal_digits(&self) -> ffi::SQLSMALLINT;
+    fn value_ptr(&self) -> ffi::SQLPOINTER;
+}
+
+impl<'a, S> Statement<'a, S> {
+    pub fn bind_parameter(&mut self, parameter_index: u16, value: u32) -> Result<()> {
+        self.raii.bind_input_parameter(parameter_index, value).into_result(self)
+    }
+}
+
+impl Raii<ffi::Stmt> {
+    fn bind_input_parameter(&mut self, parameter_index: u16, value: u32) -> Return<()> {
+
+        use std::ptr::null_mut;
+        let indicator = null_mut();
+        match unsafe {
+                  ffi::SQLBindParameter(
+                self.handle(),
+                parameter_index,
+                ffi::SQL_PARAM_INPUT,
+                ffi::SQL_C_ULONG,
+                ffi::SQL_UNKNOWN_TYPE,
+                4, // column size
+                0, // decimal digits
+                &value as *const u32 as ffi::SQLPOINTER, // parameter value ptr
+                0, // buffer length
+                indicator // str len or ind ptr
+            )
+              } {
+            ffi::SQL_SUCCESS => Return::Success(()),
+            ffi::SQL_SUCCESS_WITH_INFO => Return::SuccessWithInfo(()),
+            ffi::SQL_ERROR => Return::Error,
+            r => panic!("Unexpected return from SQLBindParameter: {:?}", r),
+        }
+    }
+}
+

--- a/src/statement/input.rs
+++ b/src/statement/input.rs
@@ -1,4 +1,5 @@
 use {ffi, Return, Result, Raii, Handle, Statement};
+use super::types::FixedSizedType;
 
 /// Allows types to be used with `Statement::bind_parameter`
 pub unsafe trait InputParameter {
@@ -10,11 +11,39 @@ pub unsafe trait InputParameter {
 }
 
 impl<'a, 'b, S> Statement<'a, 'b, S> {
+    /// Binds a parameter to a parameter marker in an SQL statement.
+    ///
+    /// # Result
+    /// This method will destroy the statement and create a new one which may not outlive the bound
+    /// parameter. This is to ensure that the statement will not derefernce an invalid pointer
+    /// during execution.
+    ///
+    /// # Arguments
+    /// * `parameter_index` - Index of the marker to bind to the parameter. Starting at `1`
+    /// * `value` - Reference to bind to the marker
+    ///
+    /// # Example
+    /// ```
+    /// # use odbc::*;
+    /// # fn do_odbc_stuff() -> std::result::Result<(), Box<std::error::Error>> {
+    ///     let env = Environment::new()?.set_odbc_version_3()?;
+    ///     let conn = DataSource::with_parent(&env)?.connect("TestDataSource", "", "")?;
+    ///     let stmt = Statement::with_parent(&conn)?;
+    ///     let param = 1968;
+    ///     let stmt = stmt.bind_parameter(1, &param)?;
+    ///     let sql_text = "SELECT TITLE FROM MOVIES WHERE YEAR = ?";
+    ///     if let Data(mut stmt) = stmt.exec_direct(sql_text)? {
+    ///         // ...
+    ///     }
+    /// #   Ok(())
+    /// # }
+    /// ```
     pub fn bind_parameter<'c, T>(mut self,
                                  parameter_index: u16,
                                  value: &'c T)
                                  -> Result<Statement<'a, 'c, S>>
         where T: InputParameter,
+              T: ?Sized,
               'b: 'c
     {
         self.raii.bind_input_parameter(parameter_index, value).into_result(&self)?;
@@ -24,7 +53,8 @@ impl<'a, 'b, S> Statement<'a, 'b, S> {
 
 impl Raii<ffi::Stmt> {
     fn bind_input_parameter<T>(&mut self, parameter_index: u16, value: &T) -> Return<()>
-        where T: InputParameter
+        where T: InputParameter,
+              T: ?Sized
     {
         match unsafe {
                   ffi::SQLBindParameter(
@@ -48,7 +78,7 @@ impl Raii<ffi::Stmt> {
     }
 }
 
-unsafe impl<'a> InputParameter for &'a str {
+unsafe impl InputParameter for str {
     fn c_data_type(&self) -> ffi::SqlCDataType {
         ffi::SQL_C_CHAR
     }
@@ -92,9 +122,11 @@ unsafe impl InputParameter for String {
     }
 }
 
-unsafe impl InputParameter for u32 {
+unsafe impl<T> InputParameter for T
+    where T: FixedSizedType
+{
     fn c_data_type(&self) -> ffi::SqlCDataType {
-        ffi::SQL_C_ULONG
+        T::c_data_type()
     }
 
     fn column_size(&self) -> ffi::SQLULEN {

--- a/src/statement/mod.rs
+++ b/src/statement/mod.rs
@@ -1,7 +1,9 @@
 
 mod types;
-mod bind_parameter;
-pub use self::types::Output;
+mod input;
+mod output;
+pub use self::output::Output;
+pub use self::input::InputParameter;
 use {ffi, DataSource, Return, Result, Raii, Handle, Connected};
 use ffi::SQLRETURN::*;
 use std::marker::PhantomData;
@@ -35,7 +37,7 @@ pub struct Statement<'a, 'b, S> {
     // for the lifetime of the statement
     parent: PhantomData<&'a DataSource<'a, Connected>>,
     state: PhantomData<S>,
-    bound: PhantomData<&'b [u8]>,
+    parameters: PhantomData<&'b [u8]>,
 }
 
 /// Used to retrieve data from the fields of a query resul
@@ -57,7 +59,7 @@ impl<'a, 'b, S> Statement<'a, 'b, S> {
             raii: raii,
             parent: PhantomData,
             state: PhantomData,
-            bound: PhantomData,
+            parameters: PhantomData,
         }
     }
 }

--- a/src/statement/output.rs
+++ b/src/statement/output.rs
@@ -1,0 +1,204 @@
+use raii::Raii;
+use {ffi, Handle, Return};
+use super::types::FixedSizedType;
+use std::ptr::null_mut;
+use std::str::from_utf8;
+use std;
+
+/// Indicates that a type can be retrieved using `Cursor::get_data`
+pub unsafe trait Output<'a>: Sized {
+    fn get_data(stmt: &mut Raii<ffi::Stmt>,
+                col_or_param_num: u16,
+                buffer: &'a mut [u8])
+                -> Return<Option<Self>>;
+}
+
+unsafe impl<'a, T> Output<'a> for T
+    where T: FixedSizedType
+{
+    fn get_data(stmt: &mut Raii<ffi::Stmt>,
+                col_or_param_num: u16,
+                _: &'a mut [u8])
+                -> Return<Option<Self>> {
+        stmt.get_data_fixed_size(col_or_param_num)
+    }
+}
+
+unsafe impl<'a> Output<'a> for String {
+    fn get_data(stmt: &mut Raii<ffi::Stmt>,
+                col_or_param_num: u16,
+                buffer: &'a mut [u8])
+                -> Return<Option<Self>> {
+        stmt.get_data_string(col_or_param_num, buffer)
+    }
+}
+
+unsafe impl<'a> Output<'a> for &'a str {
+    fn get_data(stmt: &mut Raii<ffi::Stmt>,
+                col_or_param_num: u16,
+                buffer: &'a mut [u8])
+                -> Return<Option<&'a str>> {
+        stmt.get_data_str(col_or_param_num, buffer)
+    }
+}
+
+impl Raii<ffi::Stmt> {
+    fn get_data_fixed_size<T>(&mut self, col_or_param_num: u16) -> Return<Option<T>>
+        where T: FixedSizedType
+    {
+        let mut out = T::default();
+        let mut indicator: ffi::SQLLEN = 0;
+        unsafe {
+            // Get buffer length...
+            let result = ffi::SQLGetData(self.handle(),
+                                         col_or_param_num,
+                                         T::c_data_type(),
+                                         &mut out as *mut T as ffi::SQLPOINTER,
+                                         std::mem::size_of::<Self>() as ffi::SQLLEN,
+                                         &mut indicator as *mut ffi::SQLLEN);
+            match result {
+                ffi::SQL_SUCCESS => {
+                    if indicator == ffi::SQL_NULL_DATA {
+                        Return::Success(None)
+                    } else {
+                        Return::Success(Some(out))
+                    }
+                }
+                ffi::SQL_SUCCESS_WITH_INFO => {
+                    if indicator == ffi::SQL_NULL_DATA {
+                        Return::Success(None)
+                    } else {
+                        Return::Success(Some(out))
+                    }
+                }
+                ffi::SQL_ERROR => Return::Error,
+                ffi::SQL_NO_DATA => panic!("SQLGetData has already returned the colmun data"),
+                r => panic!("unexpected return value from SQLGetData: {:?}", r),
+            }
+        }
+    }
+
+    fn get_data_str<'a>(&mut self,
+                        col_or_param: u16,
+                        buffer: &'a mut [u8])
+                        -> Return<Option<&'a str>> {
+        if buffer.len() == 0 {
+            panic!("buffer length may not be null");
+        }
+        if buffer.len() > ffi::SQLLEN::max_value() as usize {
+            panic!("buffer is larger than {} bytes", ffi::SQLLEN::max_value());
+        }
+        let mut indicator: ffi::SQLLEN = 0;
+        unsafe {
+            // Get buffer length...
+            let result = ffi::SQLGetData(self.handle(),
+                                         col_or_param,
+                                         ffi::SQL_C_CHAR,
+                                         buffer.as_mut_ptr() as ffi::SQLPOINTER,
+                                         buffer.len() as ffi::SQLLEN,
+                                         &mut indicator as *mut ffi::SQLLEN);
+            match result {
+                ffi::SQL_SUCCESS => {
+                    if indicator == ffi::SQL_NULL_DATA {
+                        Return::Success(None)
+                    } else {
+                        Return::Success(Some(from_utf8(&buffer[..(indicator as usize)]).unwrap()))
+                    }
+                }
+                ffi::SQL_SUCCESS_WITH_INFO => {
+                    if indicator == ffi::SQL_NULL_DATA {
+                        Return::SuccessWithInfo(None)
+                    } else {
+                        if indicator >= buffer.len() as ffi::SQLLEN {
+                            panic!("Buffer is not large enough to hold string")
+                        } else {
+                            Return::SuccessWithInfo(Some(from_utf8(&buffer[..(indicator as
+                                                                       usize)])
+                                                                 .unwrap()))
+                        }
+                    }
+                }
+                ffi::SQL_ERROR => Return::Error,
+                ffi::SQL_NO_DATA => panic!("SQLGetData has already returned the colmun data"),
+                r => panic!("unexpected return value from SQLGetData: {:?}", r),
+            }
+        }
+    }
+
+    fn get_data_string(&mut self,
+                       col_or_param_num: u16,
+                       buffer: &mut [u8])
+                       -> Return<Option<String>> {
+        if buffer.len() == 0 {
+            panic!("buffer length may not be null");
+        }
+        if buffer.len() > ffi::SQLLEN::max_value() as usize {
+            panic!("buffer is larger than {} bytes", ffi::SQLLEN::max_value());
+        }
+
+        let mut indicator: ffi::SQLLEN = 0;
+        unsafe {
+            // Get buffer length...
+            let result = ffi::SQLGetData(self.handle(),
+                                         col_or_param_num,
+                                         ffi::SQL_C_CHAR,
+                                         buffer.as_mut_ptr() as ffi::SQLPOINTER,
+                                         buffer.len() as ffi::SQLLEN,
+                                         &mut indicator as *mut ffi::SQLLEN);
+            match result {
+                ffi::SQL_SUCCESS => {
+                    if indicator == ffi::SQL_NULL_DATA {
+                        Return::Success(None)
+                    } else {
+                        Return::Success(Some(from_utf8(&buffer[..(indicator as usize)])
+                                                 .unwrap()
+                                                 .to_owned()))
+                    }
+                }
+                ffi::SQL_SUCCESS_WITH_INFO => {
+                    if indicator == ffi::SQL_NO_TOTAL {
+                        Return::SuccessWithInfo(None)
+                    } else {
+                        // Check if string has been truncated. String is also truncated if
+                        // indicator is equal to BUF_LENGTH because of terminating nul
+                        if indicator >= buffer.len() as ffi::SQLLEN {
+                            let extra_space = (indicator as usize + 1) - (buffer.len() - 1);
+                            let mut heap_buf = Vec::with_capacity((indicator as usize) + 1);
+                            // Copy everything but the terminating zero into the new buffer
+                            heap_buf.extend_from_slice(&buffer[..(buffer.len() - 1)]);
+                            // increase length
+                            heap_buf.extend(std::iter::repeat(0).take(extra_space));
+                            // Get remainder of string
+                            let ret = ffi::SQLGetData(self.handle(),
+                                                      col_or_param_num,
+                                                      ffi::SQL_C_CHAR,
+                                                      heap_buf.as_mut_slice()[buffer.len() - 1..]
+                                                          .as_mut_ptr() as
+                                                      ffi::SQLPOINTER,
+                                                      extra_space as ffi::SQLLEN,
+                                                      null_mut());
+                            heap_buf.pop();
+                            let value = String::from_utf8(heap_buf).unwrap();
+                            match ret {
+                                ffi::SQL_SUCCESS => Return::Success(Some(value)),
+                                ffi::SQL_SUCCESS_WITH_INFO => Return::SuccessWithInfo(Some(value)),
+                                ffi::SQL_ERROR => Return::Error,
+                                r => panic!("SQLGetData returned {:?}", r),
+                            }
+                        } else {
+                            // No truncation. Warning may be due to some other issue.
+                            Return::SuccessWithInfo(Some(from_utf8(&buffer[..(indicator as
+                                                                       usize)])
+                                                                 .unwrap()
+                                                                 .to_owned()))
+                        }
+                    }
+                }
+                ffi::SQL_ERROR => Return::Error,
+                ffi::SQL_NO_DATA => panic!("SQLGetData has already returned the colmun data"),
+                r => panic!("unexpected return value from SQLGetData: {:?}", r),
+            }
+        }
+    }
+}
+

--- a/src/statement/types.rs
+++ b/src/statement/types.rs
@@ -1,268 +1,67 @@
-use raii::Raii;
-use {ffi, Handle, Return};
-use std::ptr::null_mut;
-use std::str::from_utf8;
-use std;
+use ffi;
 
 /// Implemented for fixed size type those representation is directly compatible with ODBC
-pub unsafe trait FixedSizeType: Sized + Default {
+pub unsafe trait FixedSizedType: Sized + Default {
     fn c_data_type() -> ffi::SqlCDataType;
 }
 
-/// Indicates that a type can be retrieved using `Cursor::get_data`
-pub unsafe trait Output<'a>: Sized {
-    fn get_data(stmt: &mut Raii<ffi::Stmt>,
-                col_or_param_num: u16,
-                buffer: &'a mut [u8])
-                -> Return<Option<Self>>;
-}
-
-unsafe impl FixedSizeType for u8 {
+unsafe impl FixedSizedType for u8 {
     fn c_data_type() -> ffi::SqlCDataType {
         ffi::SQL_C_UTINYINT
     }
 }
 
-unsafe impl FixedSizeType for i8 {
+unsafe impl FixedSizedType for i8 {
     fn c_data_type() -> ffi::SqlCDataType {
         ffi::SQL_C_STINYINT
     }
 }
 
-unsafe impl FixedSizeType for i16 {
+unsafe impl FixedSizedType for i16 {
     fn c_data_type() -> ffi::SqlCDataType {
         ffi::SQL_C_SSHORT
     }
 }
 
-unsafe impl FixedSizeType for u16 {
+unsafe impl FixedSizedType for u16 {
     fn c_data_type() -> ffi::SqlCDataType {
         ffi::SQL_C_USHORT
     }
 }
 
-unsafe impl FixedSizeType for i32 {
+unsafe impl FixedSizedType for i32 {
     fn c_data_type() -> ffi::SqlCDataType {
         ffi::SQL_C_SLONG
     }
 }
 
-unsafe impl FixedSizeType for u32 {
+unsafe impl FixedSizedType for u32 {
     fn c_data_type() -> ffi::SqlCDataType {
         ffi::SQL_C_ULONG
     }
 }
 
-unsafe impl FixedSizeType for i64 {
+unsafe impl FixedSizedType for i64 {
     fn c_data_type() -> ffi::SqlCDataType {
         ffi::SQL_C_SBIGINT
     }
 }
 
-unsafe impl FixedSizeType for u64 {
+unsafe impl FixedSizedType for u64 {
     fn c_data_type() -> ffi::SqlCDataType {
         ffi::SQL_C_UBIGINT
     }
 }
 
-unsafe impl FixedSizeType for f32 {
+unsafe impl FixedSizedType for f32 {
     fn c_data_type() -> ffi::SqlCDataType {
         ffi::SQL_C_FLOAT
     }
 }
 
-unsafe impl FixedSizeType for f64 {
+unsafe impl FixedSizedType for f64 {
     fn c_data_type() -> ffi::SqlCDataType {
         ffi::SQL_C_DOUBLE
-    }
-}
-
-unsafe impl<'a, T> Output<'a> for T
-    where T: FixedSizeType
-{
-    fn get_data(stmt: &mut Raii<ffi::Stmt>,
-                col_or_param_num: u16,
-                _: &'a mut [u8])
-                -> Return<Option<Self>> {
-        stmt.get_data_fixed_size(col_or_param_num)
-    }
-}
-
-unsafe impl<'a> Output<'a> for String {
-    fn get_data(stmt: &mut Raii<ffi::Stmt>,
-                col_or_param_num: u16,
-                buffer: &'a mut [u8])
-                -> Return<Option<Self>> {
-        stmt.get_data_string(col_or_param_num, buffer)
-    }
-}
-
-unsafe impl<'a> Output<'a> for &'a str {
-    fn get_data(stmt: &mut Raii<ffi::Stmt>,
-                col_or_param_num: u16,
-                buffer: &'a mut [u8])
-                -> Return<Option<&'a str>> {
-        stmt.get_data_str(col_or_param_num, buffer)
-    }
-}
-
-impl Raii<ffi::Stmt> {
-    fn get_data_fixed_size<T>(&mut self, col_or_param_num: u16) -> Return<Option<T>>
-        where T: FixedSizeType
-    {
-        let mut out = T::default();
-        let mut indicator: ffi::SQLLEN = 0;
-        unsafe {
-            // Get buffer length...
-            let result = ffi::SQLGetData(self.handle(),
-                                         col_or_param_num,
-                                         T::c_data_type(),
-                                         &mut out as *mut T as ffi::SQLPOINTER,
-                                         std::mem::size_of::<Self>() as ffi::SQLLEN,
-                                         &mut indicator as *mut ffi::SQLLEN);
-            match result {
-                ffi::SQL_SUCCESS => {
-                    if indicator == ffi::SQL_NULL_DATA {
-                        Return::Success(None)
-                    } else {
-                        Return::Success(Some(out))
-                    }
-                }
-                ffi::SQL_SUCCESS_WITH_INFO => {
-                    if indicator == ffi::SQL_NULL_DATA {
-                        Return::Success(None)
-                    } else {
-                        Return::Success(Some(out))
-                    }
-                }
-                ffi::SQL_ERROR => Return::Error,
-                ffi::SQL_NO_DATA => panic!("SQLGetData has already returned the colmun data"),
-                r => panic!("unexpected return value from SQLGetData: {:?}", r),
-            }
-        }
-    }
-
-    fn get_data_str<'a>(&mut self,
-                        col_or_param: u16,
-                        buffer: &'a mut [u8])
-                        -> Return<Option<&'a str>> {
-        if buffer.len() == 0 {
-            panic!("buffer length may not be null");
-        }
-        if buffer.len() > ffi::SQLLEN::max_value() as usize {
-            panic!("buffer is larger than {} bytes", ffi::SQLLEN::max_value());
-        }
-        let mut indicator: ffi::SQLLEN = 0;
-        unsafe {
-            // Get buffer length...
-            let result = ffi::SQLGetData(self.handle(),
-                                         col_or_param,
-                                         ffi::SQL_C_CHAR,
-                                         buffer.as_mut_ptr() as ffi::SQLPOINTER,
-                                         buffer.len() as ffi::SQLLEN,
-                                         &mut indicator as *mut ffi::SQLLEN);
-            match result {
-                ffi::SQL_SUCCESS => {
-                    if indicator == ffi::SQL_NULL_DATA {
-                        Return::Success(None)
-                    } else {
-                        Return::Success(Some(from_utf8(&buffer[..(indicator as usize)]).unwrap()))
-                    }
-                }
-                ffi::SQL_SUCCESS_WITH_INFO => {
-                    if indicator == ffi::SQL_NULL_DATA {
-                        Return::SuccessWithInfo(None)
-                    } else {
-                        if indicator >= buffer.len() as ffi::SQLLEN {
-                            panic!("Buffer is not large enough to hold string")
-                        } else {
-                            Return::SuccessWithInfo(Some(from_utf8(&buffer[..(indicator as
-                                                                       usize)])
-                                                                 .unwrap()))
-                        }
-                    }
-                }
-                ffi::SQL_ERROR => Return::Error,
-                ffi::SQL_NO_DATA => panic!("SQLGetData has already returned the colmun data"),
-                r => panic!("unexpected return value from SQLGetData: {:?}", r),
-            }
-        }
-    }
-
-    fn get_data_string(&mut self,
-                       col_or_param_num: u16,
-                       buffer: &mut [u8])
-                       -> Return<Option<String>> {
-        if buffer.len() == 0 {
-            panic!("buffer length may not be null");
-        }
-        if buffer.len() > ffi::SQLLEN::max_value() as usize {
-            panic!("buffer is larger than {} bytes", ffi::SQLLEN::max_value());
-        }
-
-        let mut indicator: ffi::SQLLEN = 0;
-        unsafe {
-            // Get buffer length...
-            let result = ffi::SQLGetData(self.handle(),
-                                         col_or_param_num,
-                                         ffi::SQL_C_CHAR,
-                                         buffer.as_mut_ptr() as ffi::SQLPOINTER,
-                                         buffer.len() as ffi::SQLLEN,
-                                         &mut indicator as *mut ffi::SQLLEN);
-            match result {
-                ffi::SQL_SUCCESS => {
-                    if indicator == ffi::SQL_NULL_DATA {
-                        Return::Success(None)
-                    } else {
-                        Return::Success(Some(from_utf8(&buffer[..(indicator as usize)])
-                                                 .unwrap()
-                                                 .to_owned()))
-                    }
-                }
-                ffi::SQL_SUCCESS_WITH_INFO => {
-                    if indicator == ffi::SQL_NO_TOTAL {
-                        Return::SuccessWithInfo(None)
-                    } else {
-                        // Check if string has been truncated. String is also truncated if
-                        // indicator is equal to BUF_LENGTH because of terminating nul
-                        if indicator >= buffer.len() as ffi::SQLLEN {
-                            let extra_space = (indicator as usize + 1) - (buffer.len() - 1);
-                            let mut heap_buf = Vec::with_capacity((indicator as usize) + 1);
-                            // Copy everything but the terminating zero into the new buffer
-                            heap_buf.extend_from_slice(&buffer[..(buffer.len() - 1)]);
-                            // increase length
-                            heap_buf.extend(std::iter::repeat(0).take(extra_space));
-                            // Get remainder of string
-                            let ret = ffi::SQLGetData(self.handle(),
-                                                      col_or_param_num,
-                                                      ffi::SQL_C_CHAR,
-                                                      heap_buf.as_mut_slice()[buffer.len() - 1..]
-                                                          .as_mut_ptr() as
-                                                      ffi::SQLPOINTER,
-                                                      extra_space as ffi::SQLLEN,
-                                                      null_mut());
-                            heap_buf.pop();
-                            let value = String::from_utf8(heap_buf).unwrap();
-                            match ret {
-                                ffi::SQL_SUCCESS => Return::Success(Some(value)),
-                                ffi::SQL_SUCCESS_WITH_INFO => Return::SuccessWithInfo(Some(value)),
-                                ffi::SQL_ERROR => Return::Error,
-                                r => panic!("SQLGetData returned {:?}", r),
-                            }
-                        } else {
-                            // No truncation. Warning may be due to some other issue.
-                            Return::SuccessWithInfo(Some(from_utf8(&buffer[..(indicator as
-                                                                       usize)])
-                                                                 .unwrap()
-                                                                 .to_owned()))
-                        }
-                    }
-                }
-                ffi::SQL_ERROR => Return::Error,
-                ffi::SQL_NO_DATA => panic!("SQLGetData has already returned the colmun data"),
-                r => panic!("unexpected return value from SQLGetData: {:?}", r),
-            }
-        }
     }
 }
 

--- a/tests/input_parameter.rs
+++ b/tests/input_parameter.rs
@@ -15,8 +15,8 @@ macro_rules! test_type {
 
         let env = Environment::new().unwrap().set_odbc_version_3().unwrap();
         let conn = DataSource::with_parent(&env).unwrap().connect("TestDataSource", "", "").unwrap();
-        let mut stmt = Statement::with_parent(&conn).unwrap();
-        stmt.bind_parameter(1, &param).unwrap();
+        let stmt = Statement::with_parent(&conn).unwrap();
+        let stmt = stmt.bind_parameter(1, &param).unwrap();
         if let Ok(Data(mut cursor)) = stmt.exec_direct($c){
             if let Some(mut row) = cursor.fetch().unwrap(){
                 let value : $t = row.get_data(1).unwrap().unwrap();

--- a/tests/input_parameter.rs
+++ b/tests/input_parameter.rs
@@ -1,21 +1,24 @@
-//! Contains test for all types supporting `get_data`
+//! Contains test for all types supporting `bind_parameter`
 //!
 //! These tests assume there is a Stage table with a Varchar in 'A', an Integer in 'B' and a Real
 //! in 'C'
 extern crate odbc;
 use odbc::*;
 
-const A: &'static str = "SELECT A FROM TEST_TYPES;";
-const B: &'static str = "SELECT B FROM TEST_TYPES;";
-const C: &'static str = "SELECT C FROM TEST_TYPES;";
+const A: &'static str = "SELECT A FROM TEST_TYPES WHERE A = ?;";
+const B: &'static str = "SELECT B FROM TEST_TYPES WHERE B = ?;";
+const C: &'static str = "SELECT C FROM TEST_TYPES WHERE C = ?;";
 
 macro_rules! test_type {
     ($t:ty, $c:expr, $e:expr) => ({
+        let param: $t = $e;
+
         let env = Environment::new().unwrap().set_odbc_version_3().unwrap();
         let conn = DataSource::with_parent(&env).unwrap().connect("TestDataSource", "", "").unwrap();
-        let stmt = Statement::with_parent(&conn).unwrap();
+        let mut stmt = Statement::with_parent(&conn).unwrap();
+        stmt.bind_parameter(1, &param).unwrap();
         if let Ok(Data(mut cursor)) = stmt.exec_direct($c){
-            if let Ok(Some(mut row)) = cursor.fetch(){
+            if let Some(mut row) = cursor.fetch().unwrap(){
                 let value : $t = row.get_data(1).unwrap().unwrap();
                 assert_eq!(value, $e);
             } else{
@@ -35,54 +38,4 @@ fn _ref_str() {
 #[test]
 fn _string() {
     test_type!(String, A, String::from("Hello, World!"))
-}
-
-#[test]
-fn _i8() {
-    test_type!(i8, B, 42)
-}
-
-#[test]
-fn _u8() {
-    test_type!(u8, B, 42)
-}
-
-#[test]
-fn _i16() {
-    test_type!(i16, B, 42)
-}
-
-#[test]
-fn _u16() {
-    test_type!(u16, B, 42)
-}
-
-#[test]
-fn _i32() {
-    test_type!(i32, B, 42)
-}
-
-#[test]
-fn _u32() {
-    test_type!(u32, B, 42)
-}
-
-#[test]
-fn _i64() {
-    test_type!(i64, B, 42)
-}
-
-#[test]
-fn _u64() {
-    test_type!(u64, B, 42)
-}
-
-#[test]
-fn _f32() {
-    test_type!(f32, C, 3.14)
-}
-
-#[test]
-fn _f64() {
-    test_type!(f64, C, 3.14)
 }

--- a/tests/input_parameter.rs
+++ b/tests/input_parameter.rs
@@ -10,17 +10,14 @@ const B: &'static str = "SELECT B FROM TEST_TYPES WHERE B = ?;";
 const C: &'static str = "SELECT C FROM TEST_TYPES WHERE C = ?;";
 
 macro_rules! test_type {
-    ($t:ty, $c:expr, $e:expr) => ({
-        let param: $t = $e;
+    ($c:expr, $e:expr) => ({
 
         let env = Environment::new().unwrap().set_odbc_version_3().unwrap();
         let conn = DataSource::with_parent(&env).unwrap().connect("TestDataSource", "", "").unwrap();
         let stmt = Statement::with_parent(&conn).unwrap();
-        let stmt = stmt.bind_parameter(1, &param).unwrap();
+        let stmt = stmt.bind_parameter(1, $e).unwrap();
         if let Ok(Data(mut cursor)) = stmt.exec_direct($c){
-            if let Some(mut row) = cursor.fetch().unwrap(){
-                let value : $t = row.get_data(1).unwrap().unwrap();
-                assert_eq!(value, $e);
+            if let Some(_) = cursor.fetch().unwrap(){
             } else{
                 panic!("Result set has been empty");
             }
@@ -32,10 +29,72 @@ macro_rules! test_type {
 
 #[test]
 fn _ref_str() {
-    test_type!(&str, A, "Hello, World!")
+    let param = "Hello, World!";
+    test_type!(A, param)
 }
 
 #[test]
 fn _string() {
-    test_type!(String, A, String::from("Hello, World!"))
+    let param = String::from("Hello, World!");
+    test_type!(A, &param)
+}
+
+#[test]
+fn _i8() {
+    let param : i8 = 42;
+    test_type!(B, &param)
+}
+
+#[test]
+fn _u8() {
+    let param : u8 = 42;
+    test_type!(B, &param)
+}
+
+#[test]
+fn _i16() {
+    let param : i16 = 42;
+    test_type!(B, &param)
+}
+
+#[test]
+fn _u16() {
+    let param : u16 = 42;
+    test_type!(B, &param)
+}
+
+#[test]
+fn _i32() {
+    let param : i32 = 42;
+    test_type!(B, &param)
+}
+
+#[test]
+fn _u32() {
+    let param : u32 = 42;
+    test_type!(B, &param)
+}
+
+#[test]
+fn _i64() {
+    let param : i64 = 42;
+    test_type!(B, &param)
+}
+
+#[test]
+fn _u64() {
+    let param : u64 = 42;
+    test_type!(B, &param)
+}
+
+#[test]
+fn _f32() {
+    let param : f32 = 42.0;
+    test_type!(B, &param)
+}
+
+#[test]
+fn _f64() {
+    let param : f64 = 3.14;
+    test_type!(C, &param)
 }

--- a/tests/libs.rs
+++ b/tests/libs.rs
@@ -149,27 +149,7 @@ fn execution_with_parameter() {
     let conn = DataSource::with_parent(&env).unwrap().connect("TestDataSource", "", "").unwrap();
     let mut stmt = Statement::with_parent(&conn).unwrap();
 
-    // unsafe {
-
-    //     use std::ptr::null_mut;
-
-    //     let mut out = null_mut();
-    //     let mut out2 = null_mut();
-    //     ffi::SQLBindParameter(
-    //         stmt.handle(),
-    //         1, //parameter_index,
-    //         ffi::SQL_PARAM_INPUT,
-    //         ffi::SQL_C_SLONG,
-    //         ffi::SQL_INTEGER,
-    //         0, // column size
-    //         0, // decimal digits
-    //         out, // parameter value ptr
-    //         0, // buffer length
-    //         out2 // str len or ind ptr
-    //     );
-    // }
-
-    stmt.bind_parameter(1, 1968);
+    stmt.bind_parameter(1, &1968).unwrap();
 
     if let Data(mut stmt) = stmt.exec_direct("SELECT TITLE FROM MOVIES WHERE YEAR = ?").unwrap() {
         let mut cursor = stmt.fetch().unwrap().unwrap();

--- a/tests/libs.rs
+++ b/tests/libs.rs
@@ -147,9 +147,9 @@ fn reuse_statement() {
 fn execution_with_parameter() {
     let env = Environment::new().unwrap().set_odbc_version_3().unwrap();
     let conn = DataSource::with_parent(&env).unwrap().connect("TestDataSource", "", "").unwrap();
-    let mut stmt = Statement::with_parent(&conn).unwrap();
-
-    stmt.bind_parameter(1, &1968).unwrap();
+    let stmt = Statement::with_parent(&conn).unwrap();
+    let param = 1968;
+    let stmt = stmt.bind_parameter(1, &param).unwrap();
 
     if let Data(mut stmt) = stmt.exec_direct("SELECT TITLE FROM MOVIES WHERE YEAR = ?").unwrap() {
         let mut cursor = stmt.fetch().unwrap().unwrap();

--- a/tests/libs.rs
+++ b/tests/libs.rs
@@ -78,7 +78,8 @@ fn test_direct_select() {
     let conn = DataSource::with_parent(&env).unwrap().connect("TestDataSource", "", "").unwrap();
     let stmt = Statement::with_parent(&conn).unwrap();
 
-    let mut stmt = match stmt.exec_direct("SELECT TITLE, YEAR FROM MOVIES ORDER BY YEAR").unwrap() {
+    let mut stmt = match stmt.exec_direct("SELECT TITLE, YEAR FROM MOVIES ORDER BY YEAR")
+        .unwrap() {
         Data(stmt) => stmt,
         NoData(_) => panic!("SELECT statement did not return result set!"),
     };
@@ -94,9 +95,9 @@ fn test_direct_select() {
     let mut actual = Vec::new();
     while let Some(mut cursor) = stmt.fetch().unwrap() {
         actual.push(Movie {
-                        title: cursor.get_data(1).unwrap().unwrap(),
-                        year: cursor.get_data(2).unwrap().unwrap(),
-                    })
+            title: cursor.get_data(1).unwrap().unwrap(),
+            year: cursor.get_data(2).unwrap().unwrap(),
+        })
     }
 
     let check = actual ==
@@ -120,16 +121,16 @@ fn reuse_statement() {
     let conn = DataSource::with_parent(&env).unwrap().connect("TestDataSource", "", "").unwrap();
     let stmt = Statement::with_parent(&conn).unwrap();
 
-    let stmt = match stmt.exec_direct("CREATE TABLE STAGE (A VARCHAR, B VARCHAR);").unwrap(){
+    let stmt = match stmt.exec_direct("CREATE TABLE STAGE (A VARCHAR, B VARCHAR);").unwrap() {
         Data(stmt) => stmt.close_cursor().unwrap(), //A result set has been returned, we need to close it.
         NoData(stmt) => stmt,
     };
-    let stmt = match stmt.exec_direct("INSERT INTO STAGE (A, B) VALUES ('Hello', 'World');").unwrap(){
+    let stmt = match stmt.exec_direct("INSERT INTO STAGE (A, B) VALUES ('Hello', 'World');")
+        .unwrap() {
         Data(stmt) => stmt.close_cursor().unwrap(),
         NoData(stmt) => stmt,
     };
-    if let Data(mut stmt) = stmt.exec_direct("SELECT A, B FROM STAGE;").unwrap()
-    {
+    if let Data(mut stmt) = stmt.exec_direct("SELECT A, B FROM STAGE;").unwrap() {
         {
             let mut cursor = stmt.fetch().unwrap().unwrap();
             assert!(cursor.get_data::<String>(1).unwrap().unwrap() == "Hello");
@@ -137,7 +138,43 @@ fn reuse_statement() {
         }
         let stmt = stmt.close_cursor().unwrap();
         stmt.exec_direct("DROP TABLE STAGE;").unwrap();
-    } else{
+    } else {
+        panic!("SELECT statement returned no result set")
+    };
+}
+
+#[test]
+fn execution_with_parameter() {
+    let env = Environment::new().unwrap().set_odbc_version_3().unwrap();
+    let conn = DataSource::with_parent(&env).unwrap().connect("TestDataSource", "", "").unwrap();
+    let mut stmt = Statement::with_parent(&conn).unwrap();
+
+    // unsafe {
+
+    //     use std::ptr::null_mut;
+
+    //     let mut out = null_mut();
+    //     let mut out2 = null_mut();
+    //     ffi::SQLBindParameter(
+    //         stmt.handle(),
+    //         1, //parameter_index,
+    //         ffi::SQL_PARAM_INPUT,
+    //         ffi::SQL_C_SLONG,
+    //         ffi::SQL_INTEGER,
+    //         0, // column size
+    //         0, // decimal digits
+    //         out, // parameter value ptr
+    //         0, // buffer length
+    //         out2 // str len or ind ptr
+    //     );
+    // }
+
+    stmt.bind_parameter(1, 1968);
+
+    if let Data(mut stmt) = stmt.exec_direct("SELECT TITLE FROM MOVIES WHERE YEAR = ?").unwrap() {
+        let mut cursor = stmt.fetch().unwrap().unwrap();
+        assert!(cursor.get_data::<String>(1).unwrap().unwrap() == "2001: A Space Odyssey");
+    } else {
         panic!("SELECT statement returned no result set")
     };
 }
@@ -210,4 +247,3 @@ fn list_system_data_sources() {
     let expected: [DataSourceInfo; 0] = [];
     assert!(sources.iter().eq(expected.iter()));
 }
-

--- a/tests/native_types.rs
+++ b/tests/native_types.rs
@@ -5,9 +5,9 @@
 extern crate odbc;
 use odbc::*;
 
-const A : &'static str = "SELECT A FROM TEST_TYPES;";
-const B : &'static str = "SELECT B FROM TEST_TYPES;";
-const C : &'static str = "SELECT C FROM TEST_TYPES;";
+const A: &'static str = "SELECT A FROM TEST_TYPES;";
+const B: &'static str = "SELECT B FROM TEST_TYPES;";
+const C: &'static str = "SELECT C FROM TEST_TYPES;";
 
 macro_rules! test_type {
     ($t:ty, $c:expr, $e:expr) => ({
@@ -28,12 +28,12 @@ macro_rules! test_type {
 }
 
 #[test]
-fn _ref_str(){
+fn _ref_str() {
     test_type!(&str, A, "Hello, World!")
 }
 
 #[test]
-fn _string(){
+fn _string() {
     test_type!(String, A, String::from("Hello, World!"))
 }
 


### PR DESCRIPTION
* adds `Statement::bind_parameter`
* an additional lifetime parameter has been added to `Statement` to ensure it does not outlive its buffers
* changing buffers while they are bound is not possible in safe code