### PR TITLE
add get raw error data functions for avoiding encoding error

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -26,6 +26,18 @@ impl DiagnosticRecord {
             message_length: 0,
         }
     }
+    /// get raw state string data.
+    pub fn get_raw_state(&self) -> &[u8] {
+        &self.state
+    }
+    /// get raw diagnostics message for avoiding encoding error.
+    pub fn get_raw_message(&self) -> &[u8] {
+        &self.message[0..self.message_length as usize]
+    }
+    /// get native odbc error number
+    pub fn get_native_error(&self) -> i32 {
+        self.native_error
+    }
 }
 
 impl fmt::Display for DiagnosticRecord {


### PR DESCRIPTION
In some non utf-8 environment(like windows with japanese locale),
panic will be occured when call DiagnosticRecord.fmt() because of encoding error.

So I add the functions for raw message data.
If raw message data can be acquired, it can be decoded with another crate(e.g. rust-encoding).