### PR TITLE
DataSource: implement Send

### DIFF
--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -57,6 +57,8 @@ impl<'a, S: DataSourceState> Drop for DataSource<'a, S> {
     }
 }
 
+unsafe impl<'a, S: Send + DataSourceState> Send for DataSource<'a, S> {}
+
 impl<'a, S: DataSourceState> DataSource<'a, S> {
     /// Deconstruct this Connection into its constituent parts.
     fn deconstruct(self) -> Raii<ffi::Dbc> {


### PR DESCRIPTION
We're trying to do connection pooling in our application and we discovered that we can't `Send` `DataSource` handles.

Raw pointers don't implement `Send` by default (`Raii<ffi::Dbc>` is the culprit) so I just added it. (See https://doc.rust-lang.org/nomicon/send-and-sync.html for background) I'm not very familiar with the details of the ODBC library so I don't know of reason why this could be a problem, but it seems to work for us.

I'm not a very strong rust programmer, so you may know of a better way.