### PR TITLE
Simplify Environment states

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ fn main() {
 
 fn connect() -> std::result::Result<(), DiagnosticRecord> {
 
-    let env = Environment::new().unwrap();
-    let env3 = env.set_odbc_version_3()?;
-
+    let env = create_environment_v3().map_err(|e|
+        e.expect("Failed to allocate ODBC Environment")
+    )?;
     let conn = DataSource::with_parent(&env3)?;
 
     let mut buffer = String::new();

--- a/examples/bind_params.rs
+++ b/examples/bind_params.rs
@@ -10,9 +10,7 @@ fn main() {
 }
 
 fn test_me() -> std::result::Result<(), DiagnosticRecord> {
-    let env = Environment::new()
-        .expect("Can't create ODBC environment")
-        .set_odbc_version_3()?;
+    let env = create_environment_v3().expect("Can't create ODBC environment");
     let conn = DataSource::with_parent(&env)?.connect(
         "PostgreSQL",
         "postgres",

--- a/examples/column_descriptions.rs
+++ b/examples/column_descriptions.rs
@@ -10,9 +10,9 @@ fn main() {
 }
 
 fn test_me() -> std::result::Result<(), DiagnosticRecord> {
-    let env = Environment::new()
-        .expect("Can't create ODBC environment")
-        .set_odbc_version_3()?;
+    let env = create_environment_v3().map_err(|e| {
+        e.expect("Can't create ODBC environment")
+    })?;
     let conn = DataSource::with_parent(&env)?.connect(
         "PostgreSQL",
         "postgres",

--- a/examples/connect.rs
+++ b/examples/connect.rs
@@ -16,10 +16,8 @@ fn main() {
 
 fn connect() -> std::result::Result<(), DiagnosticRecord> {
 
-    let env = Environment::new().unwrap();
-    let env3 = env.set_odbc_version_3()?;
-
-    let conn = DataSource::with_parent(&env3)?;
+    let env = create_environment_v3().map_err(|e| e.unwrap())?;
+    let conn = DataSource::with_parent(&env)?;
 
     let mut buffer = String::new();
     println!("Please enter connection string: ");

--- a/examples/custom_get_data.rs
+++ b/examples/custom_get_data.rs
@@ -46,9 +46,9 @@ fn main() {
 }
 
 fn test_me() -> std::result::Result<Option<DateTime<Local>>, DiagnosticRecord> {
-    let env = Environment::new()
-        .expect("Can't create ODBC environment")
-        .set_odbc_version_3()?;
+    let env = create_environment_v3().map_err(|e| {
+        e.expect("Can't create ODBC environment")
+    })?;
     let conn = DataSource::with_parent(&env)?.connect(
         "PostgreSQL",
         "postgres",

--- a/examples/print_drivers_and_datasources.rs
+++ b/examples/print_drivers_and_datasources.rs
@@ -15,11 +15,10 @@ fn print_drivers_and_datasources() -> odbc::Result<()> {
 
     env_logger::init().unwrap();
 
-    let env = Environment::new().unwrap();
-    let mut env3 = env.set_odbc_version_3()?;
+    let mut env = create_environment_v3().map_err(|e| e.unwrap())?;
 
     println!("Driver list:");
-    for driver_info in env3.drivers()? {
+    for driver_info in env.drivers()? {
         println!("\nDriver Name: {}", driver_info.description);
         for (key, value) in driver_info.attributes {
             println!("    {}={}", key, value);
@@ -27,7 +26,7 @@ fn print_drivers_and_datasources() -> odbc::Result<()> {
     }
 
     println!("\nDataSource list:");
-    for ds in env3.data_sources()? {
+    for ds in env.data_sources()? {
         println!("    {}\n    {}\n\n", ds.server_name, ds.driver);
     }
     Ok(())

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -1,11 +1,9 @@
 //! Implements the ODBC Environment
 mod list_data_sources;
 pub use self::list_data_sources::{DataSourceInfo, DriverInfo};
-use super::{ffi, into_result, safe, try_into_option, EnvAllocError, GetDiagRec, Handle, Result};
+use super::{ffi, into_result, safe, try_into_option, DiagnosticRecord, GetDiagRec, Handle, Result};
 use std;
 
-/// Environment state used to represent that no odbc version has been set.
-pub type NoVersion = safe::NoVersion;
 /// Environment state used to represent that environment has been set to odbc version 3
 pub type Version3 = safe::Odbc3;
 
@@ -24,51 +22,31 @@ impl<V> Handle for Environment<V> {
     }
 }
 
-impl Environment<NoVersion> {
-    /// Allocates a new ODBC Environment
-    ///
-    /// After creation the `Environment` is in the `NoVersion` state. To do something with it you
-    /// need to set the ODBC Version using `set_odbc_version_3`.
+impl<V: safe::Version> Environment<V> {
+    /// Creates an ODBC Environment and declares specifaciton of `V` are used
     ///
     /// # Example
     /// ```
-    /// # use odbc::*;
-    /// let env = match Environment::new(){
-    ///     // Successful creation of Environment
-    ///     Ok(env) => env,
-    ///     // Sadly, we do not know the reason for failure, because there is no `Environment` to
-    ///     // to get the `DiagnosticRecord` from.
-    ///     Err(EnvAllocError) => panic!("Could not create an ODBC Environment."),
-    /// };
-    /// ```
-    pub fn new() -> std::result::Result<Environment<NoVersion>, EnvAllocError> {
-
-        match safe::Environment::new() {
-            safe::Success(safe) => Ok(Environment { safe }),
-            safe::Info(safe) => {
-                warn!("{}", safe.get_diag_rec(1).unwrap());
-                Ok(Environment { safe })
-            }
-            safe::Error(()) => Err(EnvAllocError),
-        }
-    }
-
-    /// Tells the driver(s) that we will use features of up to ODBC version 3
-    ///
-    /// The first thing to do with an ODBC `Environment` is to set a version.
-    ///
-    /// # Example
-    /// ```
-    /// fn do_database_stuff() -> std::result::Result<(), Box<std::error::Error>> {
-    ///     use odbc::*;
-    ///     let env = Environment::new()?.set_odbc_version_3()?; // first thing to do
+    /// use odbc::*;
+    /// fn do_database_stuff() -> std::result::Result<(), Option<DiagnosticRecord>> {
+    ///     let env : Environment<Version3> = Environment::new()?; // first thing to do
     ///     // ...
     ///     Ok(())
     /// }
     /// ```
-    pub fn set_odbc_version_3(self) -> Result<Environment<Version3>> {
-        let env = into_result(self.safe.declare_version_3())?;
-        Ok(Environment { safe: env })
+    ///
+    /// You can use the shorthand `create_environment_v3()` instead.
+    pub fn new() -> std::result::Result<Environment<V>, Option<DiagnosticRecord>> {
+        let safe = match safe::Environment::new() {
+            safe::Success(v) => v,
+            safe::Info(v) => {
+                warn!("{}", v.get_diag_rec(1).unwrap());
+                v
+            }
+            safe::Error(()) => return Err(None),
+        };
+        let safe = into_result(safe.declare_version())?;
+        Ok(Environment { safe })
     }
 }
 
@@ -80,4 +58,21 @@ unsafe impl<V> safe::Handle for Environment<V> {
     fn handle_type() -> ffi::HandleType {
         ffi::SQL_HANDLE_ENV
     }
+}
+
+/// Creates an ODBC Environment and declares specifaciton of version 3.0 are used
+///
+/// # Example
+/// ```
+/// use odbc::*;
+/// fn do_database_stuff() -> std::result::Result<(), Option<DiagnosticRecord>> {
+///     let env = create_environment_v3()?; // first thing to do
+///     // ...
+///     Ok(())
+/// }
+/// ```
+pub fn create_environment_v3()
+    -> std::result::Result<Environment<Version3>, Option<DiagnosticRecord>>
+{
+    Environment::new()
 }

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -23,7 +23,8 @@ impl<V> Handle for Environment<V> {
 }
 
 impl<V: safe::Version> Environment<V> {
-    /// Creates an ODBC Environment and declares specifaciton of `V` are used
+    /// Creates an ODBC Environment and declares specifaciton of `V` are used. You can use the
+    /// shorthand `create_environment_v3()` instead.
     ///
     /// # Example
     /// ```
@@ -35,7 +36,14 @@ impl<V: safe::Version> Environment<V> {
     /// }
     /// ```
     ///
-    /// You can use the shorthand `create_environment_v3()` instead.
+    /// # Return
+    ///
+    /// While most functions in this crate return a `DiagnosticRecord` in the event of an Error the
+    /// creation of an environment is special. Since `DiagnosticRecord`s are created using the
+    /// environment, at least its allocation has to be successful to obtain one. If the allocation
+    /// fails it is sadly not possible to receive further Diagnostics. Setting an unsupported version
+    /// may however result in an ordinary `Some(DiagnosticRecord)`.
+    /// ```
     pub fn new() -> std::result::Result<Environment<V>, Option<DiagnosticRecord>> {
         let safe = match safe::Environment::new() {
             safe::Success(v) => v,
@@ -71,6 +79,14 @@ unsafe impl<V> safe::Handle for Environment<V> {
 ///     Ok(())
 /// }
 /// ```
+///
+/// # Return
+///
+/// While most functions in this crate return a `DiagnosticRecord` in the event of an Error the
+/// creation of an environment is special. Since `DiagnosticRecord`s are created using the
+/// environment, at least its allocation has to be successful to obtain one. If the allocation
+/// fails it is sadly not possible to receive further Diagnostics. Setting an unsupported version
+/// may however result in an ordinary `Some(DiagnosticRecord)`.
 pub fn create_environment_v3()
     -> std::result::Result<Environment<Version3>, Option<DiagnosticRecord>>
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ use raii::Raii;
 use result::{Return, into_result, try_into_option};
 use odbc_safe as safe;
 pub use diagnostics::{DiagnosticRecord, GetDiagRec};
-pub use result::{Result, EnvAllocError};
+pub use result::Result;
 pub use environment::*;
 pub use data_source::{DataSource, Connected, Disconnected};
 pub use statement::*;

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,7 +1,6 @@
 //! Result types to enabling handling of ODBC Errors
 use super::{DiagnosticRecord, GetDiagRec};
 use safe;
-use std::fmt::{Display, Formatter};
 use std;
 
 /// Result type returned by most functions in this crate
@@ -102,29 +101,5 @@ where
             }
             Err(diag)
         }
-    }
-}
-
-/// Environment allocation error
-///
-/// Allocating an environment is the one operation in ODBC which does not yiel a diagnostic record
-/// in case of an error. There is simply no Environment to ask for a diagnostic record
-#[derive(Debug)]
-pub struct EnvAllocError;
-
-impl Display for EnvAllocError {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        use std::error::Error;
-        write!(f, "{}", self.description())
-    }
-}
-
-impl std::error::Error for EnvAllocError {
-    fn description(&self) -> &str {
-        "Failure to allocate ODBC environment"
-    }
-
-    fn cause(&self) -> Option<&std::error::Error> {
-        None
     }
 }

--- a/src/statement/input.rs
+++ b/src/statement/input.rs
@@ -17,7 +17,7 @@ impl<'a, 'b, S, R> Statement<'a, 'b, S, R> {
     /// ```
     /// # use odbc::*;
     /// # fn do_odbc_stuff() -> std::result::Result<(), Box<std::error::Error>> {
-    /// let env = Environment::new()?.set_odbc_version_3()?;
+    /// let env = create_environment_v3().map_err(|e| e.unwrap())?;
     /// let conn = DataSource::with_parent(&env)?.connect("TestDataSource", "", "")?;
     /// let stmt = Statement::with_parent(&conn)?;
     /// let param = 1968;

--- a/src/statement/mod.rs
+++ b/src/statement/mod.rs
@@ -145,7 +145,7 @@ impl<'a, 'b, S> Statement<'a, 'b, S, HasResult> {
     /// ```
     /// # use odbc::*;
     /// # fn reuse () -> Result<()> {
-    /// let env = Environment::new().unwrap().set_odbc_version_3()?;
+    /// let env = create_environment_v3().map_err(|e| e.unwrap())?;
     /// let conn = DataSource::with_parent(&env)?.connect("TestDataSource", "", "")?;
     /// let stmt = Statement::with_parent(&conn)?;
     /// let stmt = match stmt.exec_direct("CREATE TABLE STAGE (A TEXT, B TEXT);")?{

--- a/src/statement/prepare.rs
+++ b/src/statement/prepare.rs
@@ -12,7 +12,7 @@ impl<'a, 'b> Statement<'a, 'b, Allocated, NoResult> {
     /// ```rust
     /// # use odbc::*;
     /// # fn doc() -> Result<()>{
-    /// let env = Environment::new().unwrap().set_odbc_version_3()?;
+    /// let env = create_environment_v3().map_err(|e| e.unwrap())?;
     /// let conn = DataSource::with_parent(&env)?.connect("TestDataSource", "", "")?;
     /// let stmt = Statement::with_parent(&conn)?;
     /// let mut stmt = stmt.prepare("SELECT TITLE FROM MOVIES WHERE YEAR = ?")?;

--- a/tests/input_parameter.rs
+++ b/tests/input_parameter.rs
@@ -12,7 +12,7 @@ const C: &'static str = "SELECT C FROM TEST_TYPES WHERE C = ?;";
 macro_rules! test_type {
     ($c:expr, $e:expr) => ({
 
-        let env = Environment::new().unwrap().set_odbc_version_3().unwrap();
+        let env = create_environment_v3().unwrap();
         let conn = DataSource::with_parent(&env).unwrap().connect("TestDataSource", "", "").unwrap();
         let stmt = Statement::with_parent(&conn).unwrap();
         let stmt = stmt.bind_parameter(1, $e).unwrap();

--- a/tests/libs.rs
+++ b/tests/libs.rs
@@ -4,8 +4,7 @@ use odbc::*;
 #[test]
 fn list_tables() {
 
-    let env = Environment::new().unwrap();
-    let env = env.set_odbc_version_3().unwrap();
+    let env = create_environment_v3().unwrap();
     let ds = DataSource::with_parent(&env).unwrap();
     let ds = ds.connect("TestDataSource", "", "").unwrap();
     // scope is required (for now) to close statement before disconnecting
@@ -20,8 +19,7 @@ fn list_tables() {
 #[test]
 fn not_read_only() {
 
-    let env = Environment::new().unwrap();
-    let env = env.set_odbc_version_3().unwrap();
+    let env = create_environment_v3().unwrap();
     let conn = DataSource::with_parent(&env).unwrap();
     let conn = conn.connect("TestDataSource", "", "").unwrap();
 
@@ -32,8 +30,7 @@ fn not_read_only() {
 #[test]
 fn implicit_disconnect() {
 
-    let env = Environment::new().unwrap();
-    let env = env.set_odbc_version_3().unwrap();
+    let env = create_environment_v3().unwrap();
     let conn = DataSource::with_parent(&env).unwrap();
     conn.connect("TestDataSource", "", "").unwrap();
 
@@ -52,8 +49,7 @@ fn invalid_connection_string() {
             found, and no default driver specified"
     };
 
-    let environment = Environment::new().unwrap();
-    let environment = environment.set_odbc_version_3().unwrap();
+    let environment = create_environment_v3().unwrap();
     let conn = DataSource::with_parent(&environment).unwrap();
     let result = conn.connect_with_connection_string("bla");
     let message = format!("{}", result.err().unwrap());
@@ -63,8 +59,7 @@ fn invalid_connection_string() {
 #[test]
 fn test_connection_string() {
 
-    let environment = Environment::new().unwrap();
-    let environment = environment.set_odbc_version_3().unwrap();
+    let environment = create_environment_v3().unwrap();
     let conn = DataSource::with_parent(&environment).unwrap();
     let conn = conn.connect_with_connection_string("dsn=TestDataSource;Uid=;Pwd=;")
         .unwrap();
@@ -73,7 +68,7 @@ fn test_connection_string() {
 
 #[test]
 fn test_direct_select() {
-    let env = Environment::new().unwrap().set_odbc_version_3().unwrap();
+    let env = create_environment_v3().unwrap();
     let conn = DataSource::with_parent(&env)
         .unwrap()
         .connect("TestDataSource", "", "")
@@ -121,7 +116,7 @@ fn test_direct_select() {
 
 #[test]
 fn reuse_statement() {
-    let env = Environment::new().unwrap().set_odbc_version_3().unwrap();
+    let env = create_environment_v3().unwrap();
     let conn = DataSource::with_parent(&env)
         .unwrap()
         .connect("TestDataSource", "", "")
@@ -153,7 +148,7 @@ fn reuse_statement() {
 
 #[test]
 fn execution_with_parameter() {
-    let env = Environment::new().unwrap().set_odbc_version_3().unwrap();
+    let env = create_environment_v3().unwrap();
     let conn = DataSource::with_parent(&env)
         .unwrap()
         .connect("TestDataSource", "", "")
@@ -177,7 +172,7 @@ fn execution_with_parameter() {
 
 #[test]
 fn prepared_execution() {
-    let env = Environment::new().unwrap().set_odbc_version_3().unwrap();
+    let env = create_environment_v3().unwrap();
     let conn = DataSource::with_parent(&env)
         .unwrap()
         .connect("TestDataSource", "", "")
@@ -214,8 +209,7 @@ fn prepared_execution() {
 #[cfg_attr(not(feature = "travis"), ignore)]
 #[test]
 fn list_drivers() {
-    let environment = Environment::new().unwrap();
-    let mut environment = environment.set_odbc_version_3().unwrap();
+    let mut environment = create_environment_v3().unwrap();
     let drivers = environment.drivers().expect("Drivers can be iterated over");
     println!("{:?}", drivers);
 
@@ -228,8 +222,7 @@ fn list_drivers() {
 #[cfg_attr(not(feature = "travis"), ignore)]
 #[test]
 fn list_data_sources() {
-    let environment = Environment::new().unwrap();
-    let mut environment = environment.set_odbc_version_3().unwrap();
+    let mut environment = create_environment_v3().unwrap();
     let sources = environment.data_sources().expect(
         "Data sources can be iterated over",
     );
@@ -251,8 +244,7 @@ fn list_data_sources() {
 #[cfg_attr(not(feature = "travis"), ignore)]
 #[test]
 fn list_user_data_sources() {
-    let environment = Environment::new().unwrap();
-    let mut environment = environment.set_odbc_version_3().unwrap();
+    let mut environment = create_environment_v3().unwrap();
     let sources = environment.user_data_sources().expect(
         "Data sources can be iterated over",
     );
@@ -274,8 +266,7 @@ fn list_user_data_sources() {
 #[cfg_attr(not(feature = "travis"), ignore)]
 #[test]
 fn list_system_data_sources() {
-    let environment = Environment::new().unwrap();
-    let mut environment = environment.set_odbc_version_3().unwrap();
+    let mut environment = create_environment_v3().unwrap();
     let sources = environment.system_data_sources().expect(
         "Data sources can be iterated over",
     );

--- a/tests/native_types.rs
+++ b/tests/native_types.rs
@@ -11,7 +11,7 @@ const C: &'static str = "SELECT C FROM TEST_TYPES;";
 
 macro_rules! test_type {
     ($t:ty, $c:expr, $e:expr) => ({
-        let env = Environment::new().unwrap().set_odbc_version_3().unwrap();
+        let env = create_environment_v3().unwrap();
         let conn = DataSource::with_parent(&env).unwrap().connect("TestDataSource", "", "").unwrap();
         let stmt = Statement::with_parent(&conn).unwrap();
         if let Ok(Data(mut cursor)) = stmt.exec_direct($c){


### PR DESCRIPTION
There no longer is a NoVersion state of the environment. While this will prevent some exotic use cases it is the right thing to do for almost every application. User who need more control could use `odbc_safe` directly.