### PR TITLE
Refactored DataSource into Connection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ travis = []
 
 [dependencies]
 odbc-sys = "0.5.1"
-odbc-safe = "0.3.2"
+odbc-safe = "0.4.0"
 log = "0.3.7"
 
 [dev-dependencies]

--- a/examples/bind_params.rs
+++ b/examples/bind_params.rs
@@ -11,10 +11,10 @@ fn main() {
 
 fn test_me() -> std::result::Result<(), DiagnosticRecord> {
     let env = create_environment_v3().expect("Can't create ODBC environment");
-    let conn = DataSource::with_parent(&env)?
-        .connect("PostgreSQL", "postgres", "postgres")?;
-    let stmt = Statement::with_parent(&conn)?
-        .prepare("select version() where ? = ?")?;
+    let conn = env.connect("PostgreSQL", "postgres", "postgres")?;
+    let stmt = Statement::with_parent(&conn)?.prepare(
+        "select version() where ? = ?",
+    )?;
 
     let param = "FOOBAR";
 

--- a/examples/column_descriptions.rs
+++ b/examples/column_descriptions.rs
@@ -13,11 +13,7 @@ fn test_me() -> std::result::Result<(), DiagnosticRecord> {
     let env = create_environment_v3().map_err(|e| {
         e.expect("Can't create ODBC environment")
     })?;
-    let conn = DataSource::with_parent(&env)?.connect(
-        "PostgreSQL",
-        "postgres",
-        "postgres",
-    )?;
+    let conn = env.connect("PostgreSQL", "postgres", "postgres")?;
     let result = Statement::with_parent(&conn)?.exec_direct(
         "select '1' as str, 1 as num, current_timestamp as timestamp, null as nul, true as boolean",
     )?;

--- a/examples/connect.rs
+++ b/examples/connect.rs
@@ -17,17 +17,16 @@ fn main() {
 fn connect() -> std::result::Result<(), DiagnosticRecord> {
 
     let env = create_environment_v3().map_err(|e| e.unwrap())?;
-    let conn = DataSource::with_parent(&env)?;
 
     let mut buffer = String::new();
     println!("Please enter connection string: ");
     io::stdin().read_line(&mut buffer).unwrap();
 
-    let conn = conn.connect_with_connection_string(&buffer)?;
+    let conn = env.connect_with_connection_string(&buffer)?;
     execute_statement(&conn)
 }
 
-fn execute_statement<'env>(conn: &DataSource<'env, Connected<'env>>) -> Result<()> {
+fn execute_statement<'env>(conn: &DataSource<'env>) -> Result<()> {
     let stmt = Statement::with_parent(conn)?;
 
     let mut sql_text = String::new();

--- a/examples/connect.rs
+++ b/examples/connect.rs
@@ -26,7 +26,7 @@ fn connect() -> std::result::Result<(), DiagnosticRecord> {
     execute_statement(&conn)
 }
 
-fn execute_statement<'env>(conn: &DataSource<'env>) -> Result<()> {
+fn execute_statement<'env>(conn: &Connection<'env>) -> Result<()> {
     let stmt = Statement::with_parent(conn)?;
 
     let mut sql_text = String::new();

--- a/examples/custom_get_data.rs
+++ b/examples/custom_get_data.rs
@@ -25,11 +25,17 @@ trait MySupportedType
 where
     Self: Sized,
 {
-    fn extract_from<'a, 'con, S>(cursor: &mut odbc::Cursor<'a, 'con, 'con, S>, index: u16) -> Option<Self>;
+    fn extract_from<'a, 'con, S>(
+        cursor: &mut odbc::Cursor<'a, 'con, 'con, S>,
+        index: u16,
+    ) -> Option<Self>;
 }
 
 impl MySupportedType for DateTime<Local> {
-    fn extract_from<'a, 'con, S>(cursor: &mut odbc::Cursor<'a, 'con, 'con, S>, index: u16) -> Option<Self> {
+    fn extract_from<'a, 'con, S>(
+        cursor: &mut odbc::Cursor<'a, 'con, 'con, S>,
+        index: u16,
+    ) -> Option<Self> {
         cursor.get_data(index).expect("Can't get column").map(
             |datetime: String| {
                 Local
@@ -49,11 +55,7 @@ fn test_me() -> std::result::Result<Option<DateTime<Local>>, DiagnosticRecord> {
     let env = create_environment_v3().map_err(|e| {
         e.expect("Can't create ODBC environment")
     })?;
-    let conn = DataSource::with_parent(&env)?.connect(
-        "PostgreSQL",
-        "postgres",
-        "postgres",
-    )?;
+    let conn = env.connect("PostgreSQL", "postgres", "postgres")?;
     let mut result = Statement::with_parent(&conn)?.exec_direct(
         "select current_timestamp",
     )?;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -66,11 +66,9 @@ impl<'env> Connection<'env> {
 }
 
 unsafe impl<'env> safe::Handle for Connection<'env> {
+    const HANDLE_TYPE: ffi::HandleType = ffi::SQL_HANDLE_DBC;
+
     fn handle(&self) -> ffi::SQLHANDLE {
         self.safe.as_raw() as ffi::SQLHANDLE
-    }
-
-    fn handle_type() -> ffi::HandleType {
-        ffi::SQL_HANDLE_DBC
     }
 }

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -63,12 +63,10 @@ impl<V: safe::Version> Environment<V> {
 }
 
 unsafe impl<V> safe::Handle for Environment<V> {
+    const HANDLE_TYPE : ffi::HandleType = ffi::SQL_HANDLE_ENV;
+
     fn handle(&self) -> ffi::SQLHANDLE {
         self.safe.as_raw() as ffi::SQLHANDLE
-    }
-
-    fn handle_type() -> ffi::HandleType {
-        ffi::SQL_HANDLE_ENV
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,22 +29,26 @@ extern crate log;
 extern crate odbc_safe;
 
 pub mod ffi;
+
+pub use diagnostics::{DiagnosticRecord, GetDiagRec};
+pub use result::Result;
+pub use environment::*;
+pub use connection::Connection;
+pub use statement::*;
+
+use odbc_object::OdbcObject;
+use raii::Raii;
+use result::{Return, into_result, try_into_option};
+use odbc_safe as safe;
+
 mod odbc_object;
 mod raii;
 mod diagnostics;
 mod result;
 mod environment;
-mod data_source;
+mod connection;
 mod statement;
-use odbc_object::OdbcObject;
-use raii::Raii;
-use result::{Return, into_result, try_into_option};
-use odbc_safe as safe;
-pub use diagnostics::{DiagnosticRecord, GetDiagRec};
-pub use result::Result;
-pub use environment::*;
-pub use data_source::{DataSource, Connected, Unconnected};
-pub use statement::*;
+
 
 /// Reflects the ability of a type to expose a valid handle
 pub trait Handle {

--- a/src/odbc_object.rs
+++ b/src/odbc_object.rs
@@ -2,27 +2,21 @@ use ffi;
 
 /// Trait to be implemented by all opaque types which are referenced by handles in the ffi layer
 pub unsafe trait OdbcObject {
+    const HANDLE_TYPE: ffi::HandleType;
     type Parent;
-    fn handle_type() -> ffi::HandleType;
 }
 
 unsafe impl OdbcObject for ffi::Env {
+    const HANDLE_TYPE: ffi::HandleType = ffi::SQL_HANDLE_ENV;
     type Parent = ();
-    fn handle_type() -> ffi::HandleType {
-        ffi::SQL_HANDLE_ENV
-    }
 }
 
 unsafe impl OdbcObject for ffi::Dbc {
+    const HANDLE_TYPE: ffi::HandleType = ffi::SQL_HANDLE_DBC;
     type Parent = ffi::Env;
-    fn handle_type() -> ffi::HandleType {
-        ffi::SQL_HANDLE_DBC
-    }
 }
 
 unsafe impl OdbcObject for ffi::Stmt {
+    const HANDLE_TYPE: ffi::HandleType = ffi::SQL_HANDLE_STMT;
     type Parent = ffi::Dbc;
-    fn handle_type() -> ffi::HandleType {
-        ffi::SQL_HANDLE_STMT
-    }
 }

--- a/src/statement/input.rs
+++ b/src/statement/input.rs
@@ -18,7 +18,7 @@ impl<'a, 'b, S, R> Statement<'a, 'b, S, R> {
     /// # use odbc::*;
     /// # fn do_odbc_stuff() -> std::result::Result<(), Box<std::error::Error>> {
     /// let env = create_environment_v3().map_err(|e| e.unwrap())?;
-    /// let conn = DataSource::with_parent(&env)?.connect("TestDataSource", "", "")?;
+    /// let conn = env.connect("TestDataSource", "", "")?;
     /// let stmt = Statement::with_parent(&conn)?;
     /// let param = 1968;
     /// let stmt = stmt.bind_parameter(1, &param)?;

--- a/src/statement/mod.rs
+++ b/src/statement/mod.rs
@@ -326,11 +326,10 @@ impl Raii<ffi::Stmt> {
 }
 
 unsafe impl<'con, 'param, C, P> safe::Handle for Statement<'con, 'param, C, P> {
+
+    const HANDLE_TYPE : ffi::HandleType = ffi::SQL_HANDLE_STMT;
+
     fn handle(&self) -> ffi::SQLHANDLE {
         <Raii<ffi::Stmt> as safe::Handle>::handle(&self.raii)
-    }
-
-    fn handle_type() -> ffi::HandleType {
-        ffi::SQL_HANDLE_STMT
     }
 }

--- a/src/statement/mod.rs
+++ b/src/statement/mod.rs
@@ -4,7 +4,7 @@ mod input;
 mod output;
 mod prepare;
 pub use self::output::Output;
-use {ffi, safe, DataSource, Return, Result, Raii, Handle};
+use {ffi, safe, Connection, Return, Result, Raii, Handle};
 use ffi::SQLRETURN::*;
 use ffi::Nullable;
 use std::marker::PhantomData;
@@ -41,7 +41,7 @@ pub struct Statement<'con, 'b, S, R> {
     raii: Raii<ffi::Stmt>,
     // we use phantom data to tell the borrow checker that we need to keep the data source alive
     // for the lifetime of the statement
-    parent: PhantomData<&'con DataSource<'con>>,
+    parent: PhantomData<&'con Connection<'con>>,
     state: PhantomData<S>,
     // Indicates wether there is an open result set or not associated with this statement.
     result: PhantomData<R>,
@@ -83,7 +83,7 @@ impl<'a, 'b, S, R> Statement<'a, 'b, S, R> {
 }
 
 impl<'a, 'b, 'env> Statement<'a, 'b, Allocated, NoResult> {
-    pub fn with_parent(ds: &'a DataSource<'env>) -> Result<Self> {
+    pub fn with_parent(ds: &'a Connection<'env>) -> Result<Self> {
         let raii = Raii::with_parent(ds).into_result(ds)?;
         Ok(Self::with_raii(raii))
     }

--- a/src/statement/mod.rs
+++ b/src/statement/mod.rs
@@ -4,7 +4,7 @@ mod input;
 mod output;
 mod prepare;
 pub use self::output::Output;
-use {ffi, safe, DataSource, Return, Result, Raii, Handle, Connected};
+use {ffi, safe, DataSource, Return, Result, Raii, Handle};
 use ffi::SQLRETURN::*;
 use ffi::Nullable;
 use std::marker::PhantomData;
@@ -41,7 +41,7 @@ pub struct Statement<'con, 'b, S, R> {
     raii: Raii<ffi::Stmt>,
     // we use phantom data to tell the borrow checker that we need to keep the data source alive
     // for the lifetime of the statement
-    parent: PhantomData<&'con DataSource<'con, Connected<'con>>>,
+    parent: PhantomData<&'con DataSource<'con>>,
     state: PhantomData<S>,
     // Indicates wether there is an open result set or not associated with this statement.
     result: PhantomData<R>,
@@ -83,7 +83,7 @@ impl<'a, 'b, S, R> Statement<'a, 'b, S, R> {
 }
 
 impl<'a, 'b, 'env> Statement<'a, 'b, Allocated, NoResult> {
-    pub fn with_parent(ds: &'a DataSource<'env, Connected<'env>>) -> Result<Self> {
+    pub fn with_parent(ds: &'a DataSource<'env>) -> Result<Self> {
         let raii = Raii::with_parent(ds).into_result(ds)?;
         Ok(Self::with_raii(raii))
     }
@@ -146,7 +146,7 @@ impl<'a, 'b, S> Statement<'a, 'b, S, HasResult> {
     /// # use odbc::*;
     /// # fn reuse () -> Result<()> {
     /// let env = create_environment_v3().map_err(|e| e.unwrap())?;
-    /// let conn = DataSource::with_parent(&env)?.connect("TestDataSource", "", "")?;
+    /// let conn = env.connect("TestDataSource", "", "")?;
     /// let stmt = Statement::with_parent(&conn)?;
     /// let stmt = match stmt.exec_direct("CREATE TABLE STAGE (A TEXT, B TEXT);")?{
     ///     // Some drivers will return an empty result set. We need to close it before we can use

--- a/src/statement/prepare.rs
+++ b/src/statement/prepare.rs
@@ -13,7 +13,7 @@ impl<'a, 'b> Statement<'a, 'b, Allocated, NoResult> {
     /// # use odbc::*;
     /// # fn doc() -> Result<()>{
     /// let env = create_environment_v3().map_err(|e| e.unwrap())?;
-    /// let conn = DataSource::with_parent(&env)?.connect("TestDataSource", "", "")?;
+    /// let conn = env.connect("TestDataSource", "", "")?;
     /// let stmt = Statement::with_parent(&conn)?;
     /// let mut stmt = stmt.prepare("SELECT TITLE FROM MOVIES WHERE YEAR = ?")?;
     ///

--- a/tests/input_parameter.rs
+++ b/tests/input_parameter.rs
@@ -13,7 +13,7 @@ macro_rules! test_type {
     ($c:expr, $e:expr) => ({
 
         let env = create_environment_v3().unwrap();
-        let conn = DataSource::with_parent(&env).unwrap().connect("TestDataSource", "", "").unwrap();
+        let conn = env.connect("TestDataSource", "", "").unwrap();
         let stmt = Statement::with_parent(&conn).unwrap();
         let stmt = stmt.bind_parameter(1, $e).unwrap();
         if let Ok(Data(mut stmt)) = stmt.exec_direct($c){

--- a/tests/libs.rs
+++ b/tests/libs.rs
@@ -5,8 +5,7 @@ use odbc::*;
 fn list_tables() {
 
     let env = create_environment_v3().unwrap();
-    let ds = DataSource::with_parent(&env).unwrap();
-    let ds = ds.connect("TestDataSource", "", "").unwrap();
+    let ds = env.connect("TestDataSource", "", "").unwrap();
     // scope is required (for now) to close statement before disconnecting
     {
         let statement = Statement::with_parent(&ds).unwrap();
@@ -20,8 +19,7 @@ fn list_tables() {
 fn not_read_only() {
 
     let env = create_environment_v3().unwrap();
-    let conn = DataSource::with_parent(&env).unwrap();
-    let mut conn = conn.connect("TestDataSource", "", "").unwrap();
+    let mut conn = env.connect("TestDataSource", "", "").unwrap();
 
     assert!(!conn.is_read_only().unwrap());
     conn.disconnect().unwrap();
@@ -31,8 +29,7 @@ fn not_read_only() {
 fn implicit_disconnect() {
 
     let env = create_environment_v3().unwrap();
-    let conn = DataSource::with_parent(&env).unwrap();
-    conn.connect("TestDataSource", "", "").unwrap();
+    env.connect("TestDataSource", "", "").unwrap();
 
     // if there would be no implicit disconnect, all the drops would panic with function sequence
     // error
@@ -50,8 +47,7 @@ fn invalid_connection_string() {
     };
 
     let environment = create_environment_v3().unwrap();
-    let conn = DataSource::with_parent(&environment).unwrap();
-    let result = conn.connect_with_connection_string("bla");
+    let result = environment.connect_with_connection_string("bla");
     let message = format!("{}", result.err().unwrap());
     assert_eq!(expected, message);
 }
@@ -60,8 +56,8 @@ fn invalid_connection_string() {
 fn test_connection_string() {
 
     let environment = create_environment_v3().unwrap();
-    let conn = DataSource::with_parent(&environment).unwrap();
-    let conn = conn.connect_with_connection_string("dsn=TestDataSource;Uid=;Pwd=;")
+    let conn = environment
+        .connect_with_connection_string("dsn=TestDataSource;Uid=;Pwd=;")
         .unwrap();
     conn.disconnect().unwrap();
 }
@@ -69,10 +65,7 @@ fn test_connection_string() {
 #[test]
 fn test_direct_select() {
     let env = create_environment_v3().unwrap();
-    let conn = DataSource::with_parent(&env)
-        .unwrap()
-        .connect("TestDataSource", "", "")
-        .unwrap();
+    let conn = env.connect("TestDataSource", "", "").unwrap();
     let stmt = Statement::with_parent(&conn).unwrap();
 
     let mut stmt = match stmt.exec_direct("SELECT TITLE, YEAR FROM MOVIES ORDER BY YEAR")
@@ -117,10 +110,7 @@ fn test_direct_select() {
 #[test]
 fn reuse_statement() {
     let env = create_environment_v3().unwrap();
-    let conn = DataSource::with_parent(&env)
-        .unwrap()
-        .connect("TestDataSource", "", "")
-        .unwrap();
+    let conn = env.connect("TestDataSource", "", "").unwrap();
     let stmt = Statement::with_parent(&conn).unwrap();
 
     let stmt = match stmt.exec_direct("CREATE TABLE STAGE (A VARCHAR, B VARCHAR);")
@@ -149,10 +139,7 @@ fn reuse_statement() {
 #[test]
 fn execution_with_parameter() {
     let env = create_environment_v3().unwrap();
-    let conn = DataSource::with_parent(&env)
-        .unwrap()
-        .connect("TestDataSource", "", "")
-        .unwrap();
+    let conn = env.connect("TestDataSource", "", "").unwrap();
     let stmt = Statement::with_parent(&conn).unwrap();
     let param = 1968;
     let stmt = stmt.bind_parameter(1, &param).unwrap();
@@ -173,10 +160,7 @@ fn execution_with_parameter() {
 #[test]
 fn prepared_execution() {
     let env = create_environment_v3().unwrap();
-    let conn = DataSource::with_parent(&env)
-        .unwrap()
-        .connect("TestDataSource", "", "")
-        .unwrap();
+    let conn = env.connect("TestDataSource", "", "").unwrap();
     let stmt = Statement::with_parent(&conn).unwrap();
     let stmt = stmt.prepare("SELECT TITLE FROM MOVIES WHERE YEAR = ?")
         .unwrap();

--- a/tests/native_types.rs
+++ b/tests/native_types.rs
@@ -12,7 +12,7 @@ const C: &'static str = "SELECT C FROM TEST_TYPES;";
 macro_rules! test_type {
     ($t:ty, $c:expr, $e:expr) => ({
         let env = create_environment_v3().unwrap();
-        let conn = DataSource::with_parent(&env).unwrap().connect("TestDataSource", "", "").unwrap();
+        let conn = env.connect("TestDataSource", "", "").unwrap();
         let stmt = Statement::with_parent(&conn).unwrap();
         if let Ok(Data(mut cursor)) = stmt.exec_direct($c){
             if let Ok(Some(mut row)) = cursor.fetch(){


### PR DESCRIPTION
The former `DataSource` now knows only the `Connected` state and has therefore been aptly renamed into `Connection`. The methods to create a `Connection` have been moved into an `Environment` `impl` to be easier to discover. All in all this removed mostly one line of code from each Test or Example and made the type signatures slightly more ergonomic. There is a small price to pay though: Connecting to a Data Source now always implies a new allocation of a Connection Handle. Users who want to avoid this have to drop down to the `odbc_safe` layer.