### PR TITLE
Fix crash on errors where no diagnostics info is available.

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -32,6 +32,19 @@ impl DiagnosticRecord {
     pub fn get_native_error(&self) -> i32 {
         self.native_error
     }
+    /// constructs an empty diagnostics message.
+    /// this is needed for errors where the driver doesn't return any diagnostics info.
+    pub fn empty() -> DiagnosticRecord {
+        let message = b"No SQL-driver error information available.";
+        let mut rec = DiagnosticRecord {
+            state: b"HY000\0".clone(),
+            message: [0u8; MAX_DIAGNOSTIC_MESSAGE_SIZE],
+            native_error: -1,
+            message_length: message.len() as ffi::SQLSMALLINT,
+        };
+        rec.message[..message.len()].copy_from_slice(message);
+        rec
+    }
 }
 
 impl fmt::Display for DiagnosticRecord {

--- a/src/environment/list_data_sources.rs
+++ b/src/environment/list_data_sources.rs
@@ -1,4 +1,4 @@
-use super::{safe, try_into_option, Environment, GetDiagRec, Result, Version3};
+use super::{safe, try_into_option, Environment, DiagnosticRecord, GetDiagRec, Result, Version3};
 use ffi;
 use std::collections::HashMap;
 use std::str::from_utf8;
@@ -193,7 +193,7 @@ impl Environment<Version3> {
                 }
                 safe::ReturnOption::NoData(()) => break,
                 safe::ReturnOption::Error(()) => {
-                    let diag = self.get_diag_rec(1).unwrap();
+                    let diag = self.get_diag_rec(1).unwrap_or_else(DiagnosticRecord::empty);
                     error!("{}", diag);
                     return Err(diag);
                 }

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -48,7 +48,7 @@ impl<V: safe::Version> Environment<V> {
         let safe = match safe::Environment::new() {
             safe::Success(v) => v,
             safe::Info(v) => {
-                warn!("{}", v.get_diag_rec(1).unwrap());
+                warn!("{}", v.get_diag_rec(1).unwrap_or_else(DiagnosticRecord::empty));
                 v
             }
             safe::Error(()) => return Err(None),

--- a/src/result.rs
+++ b/src/result.rs
@@ -27,7 +27,7 @@ impl<T> Return<T> {
             }
             Return::Error => {
                 // Return the first record
-                let diag = odbc_object.get_diag_rec(1).unwrap();
+                let diag = odbc_object.get_diag_rec(1).unwrap_or_else(DiagnosticRecord::empty);
                 error!("{}", diag);
                 let mut i = 2;
                 // log the rest
@@ -60,7 +60,7 @@ where
         safe::ReturnOption::NoData(_) => Ok(None),
         safe::ReturnOption::Error(_) => {
             // Return the first record
-            let diag = handle.get_diag_rec(1).unwrap();
+            let diag = handle.get_diag_rec(1).unwrap_or_else(DiagnosticRecord::empty);
             error!("{}", diag);
             let mut i = 2;
             // log the rest
@@ -91,7 +91,7 @@ where
         }
         safe::Return::Error(value) => {
             // Return the first record
-            let diag = value.get_diag_rec(1).unwrap();
+            let diag = value.get_diag_rec(1).unwrap_or_else(DiagnosticRecord::empty);
             error!("{}", diag);
             let mut i = 2;
             // log the rest
@@ -121,7 +121,7 @@ where
         }
         safe::Return::Error(_) => {
             // Return the first record
-            let diag_rec = diag.get_diag_rec(1).unwrap();
+            let diag_rec = diag.get_diag_rec(1).unwrap_or_else(DiagnosticRecord::empty);
             error!("{}", diag_rec);
             let mut i = 2;
             // log the rest


### PR DESCRIPTION
Some drivers can return no diagnostics data after encountering certain errors. This was resulting in a panic because of the forceful unwrap of `None` values.