### PR TITLE
Add support for retrieving wide strings as UTF-16

### DIFF
--- a/src/statement/types.rs
+++ b/src/statement/types.rs
@@ -57,6 +57,49 @@ unsafe impl<'a> OdbcType<'a> for Vec<u8> {
     }
 }
 
+unsafe impl<'a> OdbcType<'a> for &'a[u16] {
+    fn sql_data_type() -> ffi::SqlDataType {
+        ffi::SQL_EXT_WVARCHAR
+    }
+    fn c_data_type() -> ffi::SqlCDataType {
+        ffi::SQL_C_WCHAR
+    }
+
+    fn convert(buffer: &'a [u8]) -> Self {
+        unsafe { from_raw_parts(buffer.as_ptr() as *const u16, buffer.len() / 2) }
+    }
+
+    fn column_size(&self) -> ffi::SQLULEN {
+        self.len() as ffi::SQLULEN
+    }
+
+    fn value_ptr(&self) -> ffi::SQLPOINTER {
+        self.as_ptr() as *const Self as ffi::SQLPOINTER
+    }
+}
+
+unsafe impl<'a> OdbcType<'a> for Vec<u16> {
+    fn sql_data_type() -> ffi::SqlDataType {
+        ffi::SQL_EXT_WVARCHAR
+    }
+    fn c_data_type() -> ffi::SqlCDataType {
+        ffi::SQL_C_WCHAR
+    }
+
+    fn convert(buffer: &'a [u8]) -> Self {
+        let buffer = unsafe { from_raw_parts(buffer.as_ptr() as *const u16, buffer.len() / 2) };
+        buffer.to_vec()
+    }
+
+    fn column_size(&self) -> ffi::SQLULEN {
+        self.len() as ffi::SQLULEN
+    }
+
+    fn value_ptr(&self) -> ffi::SQLPOINTER {
+        self.as_ptr() as *const Self as ffi::SQLPOINTER
+    }
+}
+
 unsafe impl<'a> OdbcType<'a> for CString {
     fn sql_data_type() -> ffi::SqlDataType {
         ffi::SQL_VARCHAR


### PR DESCRIPTION
When asked for `char-8` strings from a wide-string column, most ODBC drivers know to encode the data as UTF-8, either by default or with some configuration changes. But some don't support UTF-8 at all and will convert Unicode strings to simple ASCII-strings, losing data in the process.

This adds the possibility to ask for `char-16` strings, which should provide a workaround to lossless retrieve the data  from wide-strings columns, when UTF-8 support is not present.