### PR TITLE
Parameter binding of Option<T> as possibly NULL value

### DIFF
--- a/src/statement/input.rs
+++ b/src/statement/input.rs
@@ -44,7 +44,12 @@ impl<'a, 'b, S, R> Statement<'a, 'b, S, R> {
             let new_size: usize = max(parameter_index as usize + 1, self.param_ind_buffers.len());
             self.param_ind_buffers.resize(new_size, 0);
         }
-        self.param_ind_buffers[parameter_index as usize] = value.column_size() as ffi::SQLLEN;
+
+        if value.value_ptr() == 0 as *const Self as ffi::SQLPOINTER {
+            self.param_ind_buffers[parameter_index as usize] = ffi::SQL_NULL_DATA;
+        } else {
+            self.param_ind_buffers[parameter_index as usize] = value.column_size() as ffi::SQLLEN;
+        }
 
         self.raii
             .bind_input_parameter(parameter_index, value, &mut self.param_ind_buffers[parameter_index as usize])

--- a/src/statement/types.rs
+++ b/src/statement/types.rs
@@ -474,3 +474,31 @@ unsafe impl<'a> OdbcType<'a> for SqlSsTime2 {
         self as *const Self as ffi::SQLPOINTER
     }
 }
+
+unsafe impl<'a, T> OdbcType<'a> for Option<T> where T: OdbcType<'a> {
+    fn sql_data_type() -> ffi::SqlDataType {
+        T::sql_data_type()
+    }
+    fn c_data_type() -> ffi::SqlCDataType {
+        T::c_data_type()
+    }
+
+    fn convert(buffer: &'a [u8]) -> Self {
+        Some(T::convert(buffer))
+    }
+
+    fn column_size(&self) -> ffi::SQLULEN {
+        if let Some(t) = self {
+            t.column_size()
+        } else {
+            0
+        }
+    }
+    fn value_ptr(&self) -> ffi::SQLPOINTER {
+        if let Some(t) = self {
+            t.value_ptr()
+        } else {
+            0 as *const Self as ffi::SQLPOINTER
+        }
+    }
+}


### PR DESCRIPTION
I have added impl of `OdbcType` for `Option<T>` where `T` is `OdbcType` and handling case of `null` value in bind parameters. This allows me to bind `None`/`NULL` values in parametrized queries.