### PR TITLE
fix for incorrect column_size and tailing null handling for Unicode strings

### DIFF
--- a/src/statement/output.rs
+++ b/src/statement/output.rs
@@ -73,8 +73,8 @@ impl Raii<ffi::Stmt> {
             }
             ffi::SQL_SUCCESS_WITH_INFO => {
                 let initial_len = buffer.len();
-                // Workaround for drivers that don't include tailing null
-                let null_offset = if *buffer.last().unwrap() == 0 { 1 } else { 0 };
+                // As a workaround for drivers that don't include tailing null(s) check if last bytes are null
+                let null_offset = if buffer.ends_with(T::null_bytes()) { T::null_bytes().len() } else { 0 };
 
                 if indicator == ffi::SQL_NO_TOTAL {
                     buffer.resize(initial_len * 2, 0);
@@ -82,7 +82,7 @@ impl Raii<ffi::Stmt> {
                 } else {
                     // Check if string has been truncated.
                     if indicator >= initial_len as ffi::SQLLEN {
-                        buffer.resize(indicator as usize + 1, 0);
+                        buffer.resize(indicator as usize + T::null_bytes().len(), 0);
                         return self.get_partial_data(col_or_param_num, buffer, initial_len - null_offset);
                     } else {
                         let slice = &buffer[..(start_pos + indicator as usize)];

--- a/src/statement/types.rs
+++ b/src/statement/types.rs
@@ -9,6 +9,9 @@ pub unsafe trait OdbcType<'a>: Sized {
     fn c_data_type() -> ffi::SqlCDataType;
     fn convert(_: &'a [u8]) -> Self;
     fn column_size(&self) -> ffi::SQLULEN;
+    fn null_bytes() -> &'static [u8] {
+        &[0]
+    }
     fn value_ptr(&self) -> ffi::SQLPOINTER;
     fn decimal_digits(&self) -> ffi::SQLSMALLINT {
         0
@@ -70,7 +73,11 @@ unsafe impl<'a> OdbcType<'a> for &'a[u16] {
     }
 
     fn column_size(&self) -> ffi::SQLULEN {
-        self.len() as ffi::SQLULEN
+        (self.len() * 2) as ffi::SQLULEN
+    }
+
+    fn null_bytes() -> &'static [u8] {
+        &[0, 0]
     }
 
     fn value_ptr(&self) -> ffi::SQLPOINTER {
@@ -92,7 +99,11 @@ unsafe impl<'a> OdbcType<'a> for Vec<u16> {
     }
 
     fn column_size(&self) -> ffi::SQLULEN {
-        self.len() as ffi::SQLULEN
+        (self.len() * 2) as ffi::SQLULEN
+    }
+
+    fn null_bytes() -> &'static [u8] {
+        &[0, 0]
     }
 
     fn value_ptr(&self) -> ffi::SQLPOINTER {


### PR DESCRIPTION
This PR fixes issue with sending only half of the Unicode string and handling of receiving of Unicode strings where two last null bytes need to be removed from intermediate buffers instead of one.