### PR TITLE
OdbcType implementation fix for i64 and u64.

### DIFF
--- a/src/statement/types.rs
+++ b/src/statement/types.rs
@@ -303,7 +303,7 @@ unsafe impl<'a> OdbcType<'a> for u32 {
 
 unsafe impl<'a> OdbcType<'a> for i64 {
     fn sql_data_type() -> ffi::SqlDataType {
-        ffi::SQL_INTEGER
+        ffi::SQL_EXT_BIGINT
     }
     fn c_data_type() -> ffi::SqlCDataType {
         ffi::SQL_C_SBIGINT
@@ -323,7 +323,7 @@ unsafe impl<'a> OdbcType<'a> for i64 {
 
 unsafe impl<'a> OdbcType<'a> for u64 {
     fn sql_data_type() -> ffi::SqlDataType {
-        ffi::SQL_INTEGER
+        ffi::SQL_EXT_BIGINT
     }
     fn c_data_type() -> ffi::SqlCDataType {
         ffi::SQL_C_UBIGINT


### PR DESCRIPTION
I found out that sqlite see no difference between different integer types. INTEGER and BIGINT has the same affinity. Therefore I can't write correct test to reproduce bug with sqlite. I saw some tests that reference to PostgresSQL, but I'm not sure I can use it with my tests.

Anyway, for MS SQL mapping i64 and u64 to SQL_EXT_BIGINT works perfectly.