### PR TITLE
Optional tables

### DIFF
--- a/src/statement/mod.rs
+++ b/src/statement/mod.rs
@@ -131,7 +131,7 @@ impl<'a, 'b, 'env> Statement<'a, 'b, Allocated, NoResult> {
     }
 
     pub fn tables_opt_str(mut self, catalog_name: Option<&str>, schema_name: Option<&str>, table_name:Option<&str>, table_type: &str) -> Result<Statement<'a, 'b, Executed, HasResult>> {
-        self.raii.tables(catalog_name, schema_name, table_name, table_type);
+        self.raii.tables(catalog_name, schema_name, table_name, table_type).into_result(&self)?;
         Ok(Statement::with_raii(self.raii))
     }
 

--- a/src/statement/mod.rs
+++ b/src/statement/mod.rs
@@ -393,9 +393,9 @@ impl Raii<ffi::Stmt> {
 
     fn tables(&mut self, catalog_name: Option<&String>, schema_name: Option<&String>, table_name: Option<&String>, table_type: &String) -> Return<()> {
         unsafe {
-            catalog: *const odbc_sys::SQLCHAR = null_mut();
-            schema: *const odbc_sys::SQLCHAR = null_mut();
-            table: *const odbc_sys::SQLCHAR = null_mut();
+            let mut catalog: *const odbc_sys::SQLCHAR = null_mut();
+            let mut schema: *const odbc_sys::SQLCHAR = null_mut();
+            let mut table: *const odbc_sys::SQLCHAR = null_mut();
 
             if catalog_name.is_some() {
                 catalog = catalog_name.unwrap().as_ptr()


### PR DESCRIPTION
As I described in Issue https://github.com/Koka/odbc-rs/issues/110, I have problems with the tables command and MariaDB.

This PR Introduces a new method, pub fn tables_opt_str, which uses optionals.