### PR TITLE
Improved error message on failed conversion to `&str`

### DIFF
--- a/src/statement/mod.rs
+++ b/src/statement/mod.rs
@@ -236,6 +236,11 @@ impl<'a, 'b, S> Statement<'a, 'b, S, HasResult> {
 
 impl<'a, 'b, 'c, S> Cursor<'a, 'b, 'c, S> {
     /// Retrieves data for a single column in the result set
+    /// 
+    /// ## Panics
+    /// 
+    /// If you try to convert to `&str` but the data can't be converted
+    /// whithout allocating an intermediate buffer.
     pub fn get_data<'d, T>(&'d mut self, col_or_param_num: u16) -> Result<Option<T>>
     where
         T: Output<'d>,

--- a/src/statement/types.rs
+++ b/src/statement/types.rs
@@ -173,7 +173,7 @@ unsafe impl<'a> OdbcType<'a> for &'a str {
         let cow = unsafe { ::environment::DB_ENCODING }.decode(buffer).0;
         match cow {
             Borrowed(strref) => strref,
-            Owned(_string) => unimplemented!(),
+            Owned(_string) => panic!("Couldn't convert data to `&str`. Try `String` or `Cow<str>` instead."),
         }
     }
 


### PR DESCRIPTION
If conversion to `&str` returnes an owned value the current version hits `unimplemented!()` function which panics wihtout any further information. This changes this to a regular `panic!()` and adds an error message which points the user in the right direction. 

Mentioned the panic-case in the docs for the relevant function since mentioning possible panic conditions is a good practice.