### PR TITLE
Travis: enable caching and fix global environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rust:
 matrix:
   allow_failures:
    - rust: nightly
+cache: cargo
 addons:
   apt:
     packages:
@@ -26,13 +27,13 @@ services:
 before_script:
  - psql -c 'create database travis_ci_test;' -U postgres
  - export ODBCINI=${PWD}/travis/odbc.ini
- - cargo install cargo-travis
+ - cargo coveralls --version || cargo install cargo-travis
  - export PATH=$HOME/.cargo/bin:$HOME/.local/bin:$PATH
 script:
  - cargo test --verbose --features travis
 after_success:
  - cargo coveralls
 env:
- - global:
+ global:
    - RUST_BACKTRACE=1
    - RUST_TEST_THREADS=1


### PR DESCRIPTION
This drops the build from about 12 minutes (per Rust version) to about 4 minutes (once there's a cache in place), mostly by just avoiding doing extra work! It also fixes the use of global environment variables as they weren't declared correctly.