### PR TITLE
moved PhantomData<'con> to Raii to prevent Raii drop after 'con drop when Statement bound to temporary at final expression in block

### DIFF
--- a/examples/custom_get_data.rs
+++ b/examples/custom_get_data.rs
@@ -14,7 +14,7 @@ trait Extract {
         T: MySupportedType;
 }
 
-impl<'a, S, AC: AutocommitMode> Extract for Cursor<'a, 'a, 'a, S, AC> {
+impl<'s, 'a: 's, S: 's, AC: AutocommitMode> Extract for Cursor<'s, 'a, 'a, S, AC> {
     fn extract<T>(&mut self, index: u16) -> Option<T>
     where
         T: MySupportedType,

--- a/src/statement/input.rs
+++ b/src/statement/input.rs
@@ -75,7 +75,7 @@ impl<'a, 'b, S, R, AC: AutocommitMode> Statement<'a, 'b, S, R, AC> {
     }
 }
 
-impl Raii<ffi::Stmt> {
+impl<'p> Raii<'p, ffi::Stmt> {
     fn bind_input_parameter<'c, T>(
         &mut self,
         parameter_index: u16,

--- a/src/statement/output.rs
+++ b/src/statement/output.rs
@@ -24,7 +24,7 @@ where
     }
 }
 
-impl Raii<ffi::Stmt> {
+impl<'p> Raii<'p, ffi::Stmt> {
     fn get_data<'a, T>(
         &mut self,
         col_or_param_num: u16,

--- a/src/statement/prepare.rs
+++ b/src/statement/prepare.rs
@@ -98,7 +98,7 @@ impl<'a, 'b, AC: AutocommitMode> Statement<'a, 'b, Prepared, NoResult, AC> {
     }
 }
 
-impl Raii<ffi::Stmt> {
+impl<'p> Raii<'p, ffi::Stmt> {
     fn prepare(&mut self, sql_text: &str) -> Return<()> {
         let bytes = unsafe { crate::environment::DB_ENCODING }.encode(sql_text).0;
         match unsafe {

--- a/tests/gbk.rs
+++ b/tests/gbk.rs
@@ -23,7 +23,7 @@ fn _exec_direct() {
         }
     } else {
         panic!("SELECT did not return result set");
-    }
+    };
 }
 
 #[test]
@@ -48,8 +48,7 @@ fn _prepare_1() {
         NoData(_) => {
             panic!("SELECT did not return result set");
         }
-    }
-
+    };
 }
 
 #[test]
@@ -77,7 +76,7 @@ fn _prepare_2() {
         }
     } else {
         panic!("SELECT did not return result set");
-    }
+    };
 }
 
 #[test]
@@ -98,7 +97,7 @@ fn exec_direct() {
         }
     } else {
         panic!("SELECT did not return result set");
-    }
+    };
 }
 
 #[test]
@@ -120,8 +119,7 @@ fn prepare_1() {
         }
     } else {
         panic!("SELECT did not return result set");
-    }
-
+    };
 }
 
 /// CustomOdbcType  for bindParameter
@@ -150,7 +148,7 @@ unsafe impl<'a> OdbcType<'a> for CustomOdbcType<'a> {
     fn value_ptr(&self) -> ffi::SQLPOINTER {
         self.data.as_ptr() as *const Self as ffi::SQLPOINTER
     }
-    
+
     fn encoded_value(&self) -> EncodedValue {
         EncodedValue::new(None)
     }
@@ -180,5 +178,5 @@ fn prepare_2() {
         }
     } else {
         panic!("SELECT did not return result set");
-    }
+    };
 }

--- a/tests/input_parameter.rs
+++ b/tests/input_parameter.rs
@@ -25,7 +25,7 @@ macro_rules! test_type {
             }
         }else{
             panic!("SELECT did not return result set");
-        }
+        };
     })
 }
 

--- a/tests/libs.rs
+++ b/tests/libs.rs
@@ -329,7 +329,7 @@ fn zero_truncation_bug() {
         NoData(stmt) => stmt,
     };
     // Reproduction of zeroes truncation bug. Until now there is no chance to query binary data
-    // with zero at 512 byte border. 
+    // with zero at 512 byte border.
     let data = vec![0;513];
     stmt
         .prepare("INSERT INTO ZERO_TRUNCATION_BUG VALUES (?)")
@@ -349,5 +349,5 @@ fn zero_truncation_bug() {
         stmt.exec_direct("DROP TABLE ZERO_TRUNCATION_BUG").unwrap();
     } else {
         panic!("SELECT statement returned no result set")
-    }
+    };
 }

--- a/tests/native_types.rs
+++ b/tests/native_types.rs
@@ -24,7 +24,7 @@ macro_rules! test_type {
             }
         } else {
             panic!("SELECT did not return result set");
-        }
+        };
     })
 }
 


### PR DESCRIPTION
Fixes #136.
This is a breaking change.

For an explanation why `;` are needed at the end of a block in the tests see: https://www.reddit.com/r/rust/comments/6dynjz/psa_temporaries_in_final_expression_in_block_live/

Note that I did not get the test to run an pass as I don't have a setup for that. Also, I did not try this with my projects as I am still not migrated to latest `odbc` version.