### PR TITLE
Add type constraints to Environment definiton

### DIFF
--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -15,11 +15,17 @@ pub static mut DB_ENCODING: &encoding_rs::Encoding = encoding_rs::UTF_8;
 /// Creating an instance of this type is the first thing you do then using ODBC. The environment
 /// must outlive all connections created with it.
 #[derive(Debug)]
-pub struct Environment<V> {
+pub struct Environment<V>
+where
+    V: safe::Version,
+{
     safe: safe::Environment<V>,
 }
 
-impl<V> Handle for Environment<V> {
+impl<V> Handle for Environment<V>
+where
+    V: safe::Version,
+{
     type To = ffi::Env;
     unsafe fn handle(&self) -> ffi::SQLHENV {
         self.safe.as_raw()
@@ -66,7 +72,10 @@ impl<V: safe::Version> Environment<V> {
     }
 }
 
-unsafe impl<V> safe::Handle for Environment<V> {
+unsafe impl<V> safe::Handle for Environment<V>
+where
+    V: safe::Version,
+{
     const HANDLE_TYPE : ffi::HandleType = ffi::SQL_HANDLE_ENV;
 
     fn handle(&self) -> ffi::SQLHANDLE {


### PR DESCRIPTION
This fixes the breaking change introduced by odbc-safe 0.5.1 (https://github.com/pacman82/odbc-safe/commit/366d5c2551841d8722b1b5a989cc333351b3de86).

I understand that you may prefer to pin the dependency to 0.5.0 and have me take this issue to the other crate, since they shouldn't have pushed a backwards-incompatible change in a patch update, but as of 2 weeks ago the crate's been deprecated, so I figured it couldn't hurt to just open this PR. Relevant issue in other crate at https://github.com/pacman82/odbc-safe/issues/16, wherein the maintainer recommends the approach of pinning to 0.5.0 in a patch update.